### PR TITLE
ci(docker): restore BUILDX_METADATA_PROVENANCE fix lost in pipeline rename

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -233,6 +233,9 @@ jobs:
           TAG_VERSION: ${{ steps.meta.outputs.version }}
           TAG_REF: ${{ steps.meta.outputs.ref }}
           USE_REGISTRY_CONTEXTS: ${{ inputs.bake-group != 'ci-base' }}
+          # Without this, BAKE_METADATA exceeds 128 KiB on multi-target
+          # groups and the summary step fails to start bash (E2BIG).
+          BUILDX_METADATA_PROVENANCE: disabled
         with:
           source: .
           push: true


### PR DESCRIPTION
## Description

The `📊 Build summary` step in `.github/workflows/docker-build.yaml` fails for the multi-target bake groups (`ci-core`, `ci-universe`, `ci-universe-cuda`) with:

```
##[error]An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/autoware/autoware'. Argument list too long
```

Failing run: [25971834233](https://github.com/youtalk/autoware/actions/runs/25971834233), job [`jazzy-amd64 / build-core / ci-core`](https://github.com/youtalk/autoware/actions/runs/25971834233/job/76347271467). The build itself succeeds — only the summary step fails.

### Root cause

This is the exact same `E2BIG` failure that `autowarefoundation/autoware#7114` already fixed.

The summary step receives the bake metadata via `BAKE_METADATA: ${{ steps.bake.outputs.metadata }}` as an environment variable. With the buildx default (`BUILDX_METADATA_PROVENANCE=min`), buildx embeds SLSA provenance — almost entirely the GitHub webhook event payload, captured once per build target — into `--metadata-file`. For a 3-target group this inflates the metadata to ~137 KB, which exceeds the Linux per-argument limit (`MAX_ARG_STRLEN` = 128 KiB), so `execve` of bash fails with `E2BIG`. Single-target groups stay under the limit and pass.

`#7114` fixed this by setting `BUILDX_METADATA_PROVENANCE: disabled` on the bake step. **That fix never reached this fork's `main`:**

- `#7114` was merged into `autowarefoundation/autoware` upstream; the fix commits live only on the `ci/fix-bake-metadata-arg-too-long` branch here.
- The current `docker-build.yaml` on `main` originates from the `docker-build-new.yaml` → `docker-build.yaml` rename in #7040, which never carried the fix.
- `git merge-base --is-ancestor` confirms the fix commit is **not** an ancestor of `main`.

### Fix

Re-apply `BUILDX_METADATA_PROVENANCE: disabled` on the `🔨 Build and push` bake step. This removes `buildx.build.provenance` from `steps.bake.outputs.metadata`, shrinking it from ~137 KB to ~2.7 KB. The summary step only reads `containerimage.digest`, and image attestations are already disabled via `provenance: false` on the same step, so nothing else is affected.

## How was this PR tested?

**Before (on `main`, no fix)** — run [25971834233](https://github.com/youtalk/autoware/actions/runs/25971834233), `ci-core` job log. The ~137 KB `BAKE_METADATA` value is echoed inline as the step environment, spanning ~1,950 log lines, then bash fails to start:

```
2026-05-16T20:53:10Z ##[group]Check build summary support
2026-05-16T20:53:10Z Build summary supported!
  ... ~1,950 lines: the ~137 KB BAKE_METADATA value (mostly SLSA provenance) ...
2026-05-16T20:53:10Z ##[error]An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/autoware/autoware'. Argument list too long
```

**After (this branch, fix applied)** — dispatched `docker-build-and-push` on this branch: run [25972868002](https://github.com/youtalk/autoware/actions/runs/25972868002). All 23 jobs pass; the `📊 Build summary` step conclusion is `success` for every `ci-core` / `ci-universe` / `ci-universe-cuda` job. Example job [`jazzy-amd64 / build-core / ci-core`](https://github.com/youtalk/autoware/actions/runs/25972868002/job/76347907569):

```
##[group]Run duration="n/a"
  ...
  BAKE_METADATA: { ... "containerimage.digest": "sha256:b9f032eb..." }   # ~2.7 KB, no provenance
##[endgroup]
📊 Build summary: success
```

**Cross-check** — run [25963598959](https://github.com/youtalk/autoware/actions/runs/25963598959) on the `ci/fix-bake-metadata-arg-too-long` branch (which already carries the fix) also passes. Identical workflow, identical `ci-core` multi-target group; the only difference is the presence of `BUILDX_METADATA_PROVENANCE: disabled` — present → pass, absent → fail.

`pre-commit` (`yamllint`, `prettier`, `check yaml`) passes on the changed workflow.
