### PR TITLE
feat(ansible): add version_lock role for reproducible dependency installation

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,3 +4,6 @@ skip_list:
   - complexity # Large task files are acceptable for our setup roles.
 
 warn_list: []
+
+exclude_paths:
+  - ansible/vars/ # Lock files use package names as keys, not Ansible variables.

--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,4 @@
+{
+  "ignorePaths": ["ansible/vars/"],
+  "words": ["lockfiles", "runpip"]
+}

--- a/ansible/playbooks/install_dev_env.yaml
+++ b/ansible/playbooks/install_dev_env.yaml
@@ -20,6 +20,10 @@
       tags: [always]
 
   roles:
+    # APT version pinning for reproducible builds (no-op pin file cleanup unless use_locked_versions=true)
+    - role: autoware.dev_env.version_lock
+      tags: [core, universe, version_lock]
+
     # Base ROS 2 environment
     - role: autoware.dev_env.ros2
       tags: [core, universe, ros2]

--- a/ansible/roles/build_tools/tasks/main.yaml
+++ b/ansible/roles/build_tools/tasks/main.yaml
@@ -3,6 +3,7 @@
   ansible.builtin.apt:
     name: ccache
     state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
     update_cache: true
 
 - name: Add CCACHE_DIR to .bashrc

--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -4,6 +4,7 @@
   ansible.builtin.apt:
     name: git-lfs
     state: present
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
     update_cache: true
 
 - name: Setup Git LFS for current user
@@ -15,6 +16,7 @@
   ansible.builtin.apt:
     name: pipx
     state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
     update_cache: true
 
 - name: Install pre-commit
@@ -32,6 +34,7 @@
   ansible.builtin.apt:
     name: golang
     state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
     update_cache: true
 
 - name: Hold check of ros-{{ rosdistro + '-plotjuggler' }}
@@ -45,6 +48,7 @@
     name:
       - ros-{{ rosdistro }}-plotjuggler
     state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
     update_cache: true
   when: "'ros-' + rosdistro + '-plotjuggler' not in dev_tools__held_ros_packages.stdout"
   register: dev_tools__install_result

--- a/ansible/roles/docker_engine/tasks/main.yaml
+++ b/ansible/roles/docker_engine/tasks/main.yaml
@@ -67,6 +67,7 @@
       - docker-ce-cli
       - containerd.io
       - docker-compose-plugin
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
     update_cache: true
 
 # sudo groupadd docker

--- a/ansible/roles/gdown/tasks/main.yaml
+++ b/ansible/roles/gdown/tasks/main.yaml
@@ -3,9 +3,10 @@
   ansible.builtin.apt:
     name: pipx
     state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
     update_cache: true
 
 - name: Install gdown to download files from CMakeLists.txt
   community.general.pipx:
-    name: gdown
+    name: "{{ 'gdown==' ~ locked_packages['gdown'] if use_locked_versions | default(false) | bool else 'gdown' }}"
     executable: /usr/bin/pipx

--- a/ansible/roles/geographiclib/tasks/main.yaml
+++ b/ansible/roles/geographiclib/tasks/main.yaml
@@ -3,6 +3,7 @@
   ansible.builtin.apt:
     name: geographiclib-tools
     state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
     update_cache: true
 
 - name: Install egm2008-1

--- a/ansible/roles/rmw_implementation/tasks/main.yaml
+++ b/ansible/roles/rmw_implementation/tasks/main.yaml
@@ -14,11 +14,12 @@
   register: rmw_implementation__held_pkgs
   changed_when: false
 
-- name: Install latest (skip if held) {{ rmw_implementation__pkg }}
+- name: Install {{ rmw_implementation__pkg }}
   become: true
   ansible.builtin.apt:
     name: "{{ rmw_implementation__pkg }}"
     state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
     update_cache: true
     cache_valid_time: 3600
   when: rmw_implementation__pkg not in rmw_implementation__held_pkgs.stdout_lines

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -1,35 +1,38 @@
-- name: Get latest release information of ros-apt-source package
-  ansible.builtin.uri:
-    url: https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest
-    method: GET
-    return_content: true
-  register: ros2__ros_apt_release_info
+- name: Download and install ros-apt-source package
+  when: not (use_locked_versions | default(false) | bool)
+  block:
+    - name: Get latest release information of ros-apt-source package
+      ansible.builtin.uri:
+        url: https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest
+        method: GET
+        return_content: true
+      register: ros2__ros_apt_release_info
 
-- name: Extract latest version of ros-apt-source package
-  ansible.builtin.set_fact:
-    ros2__ros_apt_source_version: "{{ (ros2__ros_apt_release_info.content | from_json).tag_name }}"
+    - name: Extract latest version of ros-apt-source package
+      ansible.builtin.set_fact:
+        ros2__ros_apt_source_version: "{{ (ros2__ros_apt_release_info.content | from_json).tag_name }}"
 
-- name: Save result of 'source /etc/os-release && echo $UBUNTU_CODENAME'
-  ansible.builtin.shell: bash -c 'source /etc/os-release && echo $UBUNTU_CODENAME'
-  register: ros2__ubuntu_codename
-  changed_when: false
+    - name: Save result of 'source /etc/os-release && echo $UBUNTU_CODENAME'
+      ansible.builtin.shell: bash -c 'source /etc/os-release && echo $UBUNTU_CODENAME'
+      register: ros2__ubuntu_codename
+      changed_when: false
 
-- name: Get ros2-apt-source package
-  ansible.builtin.get_url:
-    url: https://github.com/ros-infrastructure/ros-apt-source/releases/download/{{ ros2__ros_apt_source_version }}/ros2-apt-source_{{ ros2__ros_apt_source_version }}.{{ ros2__ubuntu_codename.stdout }}_all.deb
-    dest: /tmp/ros2-apt-source.deb
-    mode: "0644"
+    - name: Get ros2-apt-source package
+      ansible.builtin.get_url:
+        url: https://github.com/ros-infrastructure/ros-apt-source/releases/download/{{ ros2__ros_apt_source_version }}/ros2-apt-source_{{ ros2__ros_apt_source_version }}.{{ ros2__ubuntu_codename.stdout }}_all.deb
+        dest: /tmp/ros2-apt-source.deb
+        mode: "0644"
 
-- name: Install ros2-apt-source package
-  ansible.builtin.apt:
-    deb: /tmp/ros2-apt-source.deb
-    state: present
-  become: true
+    - name: Install ros2-apt-source package
+      ansible.builtin.apt:
+        deb: /tmp/ros2-apt-source.deb
+        state: present
+      become: true
 
-- name: Delete installed .deb file
-  ansible.builtin.file:
-    path: /tmp/ros2-apt-source.deb
-    state: absent
+    - name: Delete installed .deb file
+      ansible.builtin.file:
+        path: /tmp/ros2-apt-source.deb
+        state: absent
 
 - name: Hold check of ros-{{ rosdistro + '-' + ros2_installation_type }}
   ansible.builtin.command: apt-mark showhold
@@ -41,6 +44,7 @@
   ansible.builtin.apt:
     name: ros-{{ rosdistro }}-{{ ros2_installation_type }}
     state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
     update_cache: true
   when: "'ros-' + rosdistro + '-' + ros2_installation_type not in ros2_held_ros_packages.stdout"
   register: ros2_install_result

--- a/ansible/roles/ros2_dev_tools/tasks/main.yaml
+++ b/ansible/roles/ros2_dev_tools/tasks/main.yaml
@@ -23,6 +23,7 @@
       - python3-vcs2l # formerly python3-vcstool
       - wget # from ros-dev-tools
     state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
     update_cache: true
 
 - name: Run 'sudo rosdep init'

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -1,0 +1,50 @@
+# version_lock
+
+## Purpose
+
+This role pins APT package versions for reproducible dependency installation. When enabled, it writes an APT preferences file (`/etc/apt/preferences.d/autoware-lock`) with `Pin-Priority: 1001` entries generated from a lockfile, forcing APT to install (or downgrade to) the exact locked versions. When disabled (the default), the role removes any existing pin file, so it is always safe to keep registered in the playbook. The lockfile covers the packages installed by the `install_dev_env` playbook; Docker Engine packages are out of scope because they are installed by the separate `install_docker` playbook.
+
+## Usage
+
+Version locking is opt-in. Enable it by setting `use_locked_versions=true`:
+
+```bash
+ansible-playbook autoware.dev_env.install_dev_env --extra-vars use_locked_versions=true --ask-become-pass
+```
+
+### Lockfile resolution
+
+The lockfile path is resolved automatically from the ROS distro and CPU architecture as `ansible/vars/locked-versions-<rosdistro>-<arch>.yaml` (e.g. `locked-versions-humble-amd64.yaml`), where `<arch>` is the Debian architecture name mapped from `ansible_architecture` (`x86_64` -> `amd64`, `aarch64` -> `arm64`).
+
+To use a custom lockfile, override `lockfile_path`:
+
+```bash
+ansible-playbook autoware.dev_env.install_dev_env --extra-vars "use_locked_versions=true lockfile_path=/path/to/my-lockfile.yaml" --ask-become-pass
+```
+
+## Generating lockfiles
+
+On a machine already provisioned by `install_dev_env`, run:
+
+```bash
+ROS_DISTRO=<distro> ./ansible/scripts/generate_ansible_lockfile.sh
+```
+
+The script reads the package names from the existing lockfile for the current distro/architecture and fills in the versions currently installed on the machine.
+
+## Validating lockfiles
+
+```bash
+./ansible/scripts/validate_lockfiles.sh
+```
+
+This checks that every `ansible/vars/locked-versions-*.yaml` file is valid YAML and a flat dictionary.
+
+## Lockfile format
+
+A flat YAML dictionary mapping `package: version`, sorted alphabetically by package name:
+
+```yaml
+ccache: 4.5.1-1
+python3-pip: 22.0.2+dfsg-1ubuntu0.4
+```

--- a/ansible/roles/version_lock/defaults/main.yaml
+++ b/ansible/roles/version_lock/defaults/main.yaml
@@ -1,0 +1,5 @@
+version_lock_arch_map:
+  x86_64: amd64
+  aarch64: arm64
+# lockfile_path is the published interface-contract variable; renaming would break consumers.
+lockfile_path: "{{ role_path }}/../../vars/locked-versions-{{ rosdistro }}-{{ version_lock_arch_map[ansible_architecture] | default(ansible_architecture) }}.yaml" # noqa: var-naming[no-role-prefix]

--- a/ansible/roles/version_lock/tasks/main.yaml
+++ b/ansible/roles/version_lock/tasks/main.yaml
@@ -1,0 +1,20 @@
+- name: Load lockfile
+  ansible.builtin.include_vars:
+    file: "{{ lockfile_path }}"
+    name: locked_packages
+  when: use_locked_versions | default(false) | bool
+
+- name: Create APT version pins
+  become: true
+  ansible.builtin.template:
+    src: autoware-lock.pref.j2
+    dest: /etc/apt/preferences.d/autoware-lock
+    mode: "0644"
+  when: use_locked_versions | default(false) | bool
+
+- name: Remove APT version pins
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/preferences.d/autoware-lock
+    state: absent
+  when: not (use_locked_versions | default(false) | bool)

--- a/ansible/roles/version_lock/templates/autoware-lock.pref.j2
+++ b/ansible/roles/version_lock/templates/autoware-lock.pref.j2
@@ -1,0 +1,8 @@
+{% for pkg, ver in locked_packages.items() %}
+{% if ver is not none and ver|string %}
+Package: {{ pkg }}
+Pin: version {{ ver }}
+Pin-Priority: 1001
+
+{% endif %}
+{% endfor %}

--- a/ansible/scripts/generate_ansible_lockfile.sh
+++ b/ansible/scripts/generate_ansible_lockfile.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ANSIBLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+if [[ -z ${ROS_DISTRO:-} ]]; then
+    echo "Error: ROS_DISTRO is not set." >&2
+    exit 1
+fi
+ARCH=$(dpkg --print-architecture)
+
+OUTPUT_FILE="${ANSIBLE_DIR}/vars/locked-versions-${ROS_DISTRO}-${ARCH}.yaml"
+
+main() {
+    echo "Generating Ansible lockfile: $OUTPUT_FILE"
+
+    if [[ ! -f $OUTPUT_FILE ]]; then
+        echo "Error: Lockfile not found: $OUTPUT_FILE" >&2
+        echo "Create the lockfile with package names first, then run this script to fill in versions." >&2
+        exit 1
+    fi
+
+    # Read package names from existing lockfile
+    local packages
+    # cspell:ignore isinstance
+    if ! packages=$(python3 -c "
+import yaml, sys
+with open('$OUTPUT_FILE') as f:
+    data = yaml.safe_load(f)
+if not isinstance(data, dict):
+    sys.stderr.write('Error: Lockfile content must be a YAML mapping (dict).\n')
+    sys.exit(1)
+for pkg in sorted(data):
+    print(pkg)
+"); then
+        echo "Error: Failed to read package list from lockfile: $OUTPUT_FILE" >&2
+        exit 1
+    fi
+
+    # Resolve all versions first, fail if any package is missing
+    declare -A versions
+    local has_error=false
+
+    # pip/pipx-managed packages (included in the same lockfile)
+    local pip_pkgs=("gdown")
+
+    # APT packages (pip/pipx-managed packages are resolved separately below)
+    for pkg in $packages; do
+        local is_pip=false
+        for pip_pkg in "${pip_pkgs[@]}"; do
+            if [[ $pkg == "$pip_pkg" ]]; then
+                is_pip=true
+                break
+            fi
+        done
+        if [[ $is_pip == "true" ]]; then
+            continue
+        fi
+        local ver
+        ver=$(dpkg-query -W -f='${Version}' "$pkg" 2>/dev/null) || true
+        if [[ -z $ver ]]; then
+            echo "Error: APT package '$pkg' is not installed." >&2
+            has_error=true
+        else
+            versions[$pkg]=$ver
+        fi
+    done
+
+    for pkg in "${pip_pkgs[@]}"; do
+        local ver
+        ver=$(pip3 show "$pkg" 2>/dev/null | grep '^Version:' | awk '{print $2}' || true)
+        if [[ -z $ver ]]; then
+            # Fall back to pipx-managed installations (e.g. the gdown role installs via pipx).
+            ver=$(pipx runpip "$pkg" show "$pkg" 2>/dev/null | grep '^Version:' | awk '{print $2}' || true)
+        fi
+        if [[ -z $ver ]]; then
+            echo "Error: pip package '$pkg' is not installed (checked pip3 and pipx)." >&2
+            has_error=true
+        else
+            versions[$pkg]=$ver
+        fi
+    done
+
+    if [[ $has_error == "true" ]]; then
+        exit 1
+    fi
+
+    # Write lockfile only after all versions are resolved
+    {
+        cat <<HEADER
+# Dependency Version Lockfile
+# cspell:ignore Iseconds
+# Generated: $(date -Iseconds)
+# ROS Distro: ${ROS_DISTRO}
+# Platform: ${ARCH}
+# Ubuntu: $(lsb_release -rs) ($(lsb_release -cs))
+
+HEADER
+
+        for pkg in $packages; do
+            echo "${pkg}: ${versions[$pkg]}"
+        done
+    } >"$OUTPUT_FILE"
+
+    echo "Generated: $OUTPUT_FILE"
+}
+
+main "$@"

--- a/ansible/scripts/validate_lockfiles.sh
+++ b/ansible/scripts/validate_lockfiles.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ANSIBLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+validate_lockfile() {
+    local lockfile="$1"
+
+    if [[ ! -f $lockfile ]]; then
+        echo "Error: Lockfile not found: $lockfile" >&2
+        return 1
+    fi
+
+    # YAML syntax check and ensure it's a flat dict
+    # cspell:ignore isinstance
+    if ! python3 -c "
+import yaml, sys
+with open('$lockfile') as f:
+    data = yaml.safe_load(f)
+if not isinstance(data, dict):
+    print('Error: Lockfile must be a YAML dict', file=sys.stderr)
+    sys.exit(1)
+for key, val in data.items():
+    if isinstance(val, dict):
+        print(f'Error: Nested dict found at key \"{key}\"', file=sys.stderr)
+        sys.exit(1)
+"; then
+        echo "Error: Invalid lockfile format in $lockfile" >&2
+        return 1
+    fi
+
+    echo "Validated: $lockfile"
+    return 0
+}
+
+main() {
+    local exit_code=0
+    local found=false
+
+    for lockfile in "${ANSIBLE_DIR}"/vars/locked-versions-*.yaml; do
+        if [[ -f $lockfile ]]; then
+            found=true
+            if ! validate_lockfile "$lockfile"; then
+                exit_code=1
+            fi
+        fi
+    done
+
+    if [[ $found == "false" ]]; then
+        echo "Error: No lock files found in ${ANSIBLE_DIR}/vars/" >&2
+        exit 1
+    fi
+
+    return $exit_code
+}
+
+main "$@"

--- a/ansible/vars/locked-versions-humble-amd64.yaml
+++ b/ansible/vars/locked-versions-humble-amd64.yaml
@@ -1,0 +1,35 @@
+# Dependency Version Lockfile
+# ROS Distro: humble
+# Platform: amd64
+#
+# Versions are empty by default.
+# Run `ROS_DISTRO=humble ./ansible/scripts/generate_ansible_lockfile.sh` to fill in versions.
+
+ccache:
+gdown:
+geographiclib-tools:
+git-lfs:
+golang:
+pipx:
+python3-bloom:
+python3-colcon-common-extensions:
+python3-colcon-mixin:
+python3-flake8-blind-except:
+python3-flake8-builtins:
+python3-flake8-class-newline:
+python3-flake8-comprehensions:
+python3-flake8-deprecated:
+python3-flake8-docstrings:
+python3-flake8-import-order:
+python3-flake8-quotes:
+python3-pip:
+python3-pytest-cov:
+python3-pytest-repeat:
+python3-pytest-rerunfailures:
+python3-rosdep:
+python3-vcs2l:
+ros-build-essential:
+ros-humble-desktop:
+ros-humble-plotjuggler:
+ros-humble-rmw-cyclonedds-cpp:
+wget:

--- a/ansible/vars/locked-versions-humble-amd64.yaml
+++ b/ansible/vars/locked-versions-humble-amd64.yaml
@@ -1,35 +1,35 @@
 # Dependency Version Lockfile
+# cspell:ignore Iseconds
+# Generated: 2026-06-13T01:33:32+00:00
 # ROS Distro: humble
 # Platform: amd64
-#
-# Versions are empty by default.
-# Run `ROS_DISTRO=humble ./ansible/scripts/generate_ansible_lockfile.sh` to fill in versions.
+# Ubuntu: 22.04 (jammy)
 
-ccache:
-gdown:
-geographiclib-tools:
-git-lfs:
-golang:
-pipx:
-python3-bloom:
-python3-colcon-common-extensions:
-python3-colcon-mixin:
-python3-flake8-blind-except:
-python3-flake8-builtins:
-python3-flake8-class-newline:
-python3-flake8-comprehensions:
-python3-flake8-deprecated:
-python3-flake8-docstrings:
-python3-flake8-import-order:
-python3-flake8-quotes:
-python3-pip:
-python3-pytest-cov:
-python3-pytest-repeat:
-python3-pytest-rerunfailures:
-python3-rosdep:
-python3-vcs2l:
-ros-build-essential:
-ros-humble-desktop:
-ros-humble-plotjuggler:
-ros-humble-rmw-cyclonedds-cpp:
-wget:
+ccache: 4.5.1-1
+gdown: 6.1.0
+geographiclib-tools: 1.52-1
+git-lfs: 3.0.2-1ubuntu0.3
+golang: 2:1.18~0ubuntu2
+pipx: 1.0.0-1
+python3-bloom: 0.14.3+upstream-1
+python3-colcon-common-extensions: 0.3.0-100
+python3-colcon-mixin: 0.2.3-100
+python3-flake8-blind-except: 0.2.0-2
+python3-flake8-builtins: 1.5.3-3
+python3-flake8-class-newline: 1.6.0-2
+python3-flake8-comprehensions: 3.8.0-1
+python3-flake8-deprecated: 1.3-3
+python3-flake8-docstrings: 1.6.0-1
+python3-flake8-import-order: 0.18.1-2
+python3-flake8-quotes: 3.3.1-2
+python3-pip: 22.0.2+dfsg-1ubuntu0.7
+python3-pytest-cov: 3.0.0-1
+python3-pytest-repeat: 0.9.1-2
+python3-pytest-rerunfailures: 10.2-1
+python3-rosdep: 0.26.0-1
+python3-vcs2l: 1.1.7-1
+ros-build-essential: 1.0.1
+ros-humble-desktop: 0.10.0-1jammy.20260423.142311
+ros-humble-plotjuggler: 3.15.0-1jammy.20260421.073046
+ros-humble-rmw-cyclonedds-cpp: 1.3.4-1jammy.20260414.141106
+wget: 1.21.2-2ubuntu1.1

--- a/ansible/vars/locked-versions-humble-arm64.yaml
+++ b/ansible/vars/locked-versions-humble-arm64.yaml
@@ -1,0 +1,35 @@
+# Dependency Version Lockfile
+# ROS Distro: humble
+# Platform: arm64
+#
+# Versions are empty by default.
+# Run `ROS_DISTRO=humble ./ansible/scripts/generate_ansible_lockfile.sh` to fill in versions.
+
+ccache:
+gdown:
+geographiclib-tools:
+git-lfs:
+golang:
+pipx:
+python3-bloom:
+python3-colcon-common-extensions:
+python3-colcon-mixin:
+python3-flake8-blind-except:
+python3-flake8-builtins:
+python3-flake8-class-newline:
+python3-flake8-comprehensions:
+python3-flake8-deprecated:
+python3-flake8-docstrings:
+python3-flake8-import-order:
+python3-flake8-quotes:
+python3-pip:
+python3-pytest-cov:
+python3-pytest-repeat:
+python3-pytest-rerunfailures:
+python3-rosdep:
+python3-vcs2l:
+ros-build-essential:
+ros-humble-desktop:
+ros-humble-plotjuggler:
+ros-humble-rmw-cyclonedds-cpp:
+wget:

--- a/ansible/vars/locked-versions-jazzy-amd64.yaml
+++ b/ansible/vars/locked-versions-jazzy-amd64.yaml
@@ -1,0 +1,35 @@
+# Dependency Version Lockfile
+# ROS Distro: jazzy
+# Platform: amd64
+#
+# Versions are empty by default.
+# Run `ROS_DISTRO=jazzy ./ansible/scripts/generate_ansible_lockfile.sh` to fill in versions.
+
+ccache:
+gdown:
+geographiclib-tools:
+git-lfs:
+golang:
+pipx:
+python3-bloom:
+python3-colcon-common-extensions:
+python3-colcon-mixin:
+python3-flake8-blind-except:
+python3-flake8-builtins:
+python3-flake8-class-newline:
+python3-flake8-comprehensions:
+python3-flake8-deprecated:
+python3-flake8-docstrings:
+python3-flake8-import-order:
+python3-flake8-quotes:
+python3-pip:
+python3-pytest-cov:
+python3-pytest-repeat:
+python3-pytest-rerunfailures:
+python3-rosdep:
+python3-vcs2l:
+ros-build-essential:
+ros-jazzy-desktop:
+ros-jazzy-plotjuggler:
+ros-jazzy-rmw-cyclonedds-cpp:
+wget:

--- a/ansible/vars/locked-versions-jazzy-amd64.yaml
+++ b/ansible/vars/locked-versions-jazzy-amd64.yaml
@@ -1,35 +1,35 @@
 # Dependency Version Lockfile
+# cspell:ignore Iseconds
+# Generated: 2026-06-13T04:02:04+00:00
 # ROS Distro: jazzy
 # Platform: amd64
-#
-# Versions are empty by default.
-# Run `ROS_DISTRO=jazzy ./ansible/scripts/generate_ansible_lockfile.sh` to fill in versions.
+# Ubuntu: 24.04 (noble)
 
-ccache:
-gdown:
-geographiclib-tools:
-git-lfs:
-golang:
-pipx:
-python3-bloom:
-python3-colcon-common-extensions:
-python3-colcon-mixin:
-python3-flake8-blind-except:
-python3-flake8-builtins:
-python3-flake8-class-newline:
-python3-flake8-comprehensions:
-python3-flake8-deprecated:
-python3-flake8-docstrings:
-python3-flake8-import-order:
-python3-flake8-quotes:
-python3-pip:
-python3-pytest-cov:
-python3-pytest-repeat:
-python3-pytest-rerunfailures:
-python3-rosdep:
-python3-vcs2l:
-ros-build-essential:
-ros-jazzy-desktop:
-ros-jazzy-plotjuggler:
-ros-jazzy-rmw-cyclonedds-cpp:
-wget:
+ccache: 4.9.1-1
+gdown: 6.1.0
+geographiclib-tools: 2.3-1build1
+git-lfs: 3.4.1-1ubuntu0.4
+golang: 2:1.22~2build1
+pipx: 1.4.3-1
+python3-bloom: 0.14.3+upstream-1
+python3-colcon-common-extensions: 0.3.0-100
+python3-colcon-mixin: 0.2.3-100
+python3-flake8-blind-except: 0.2.1-1
+python3-flake8-builtins: 2.1.0-1
+python3-flake8-class-newline: 1.6.0-5
+python3-flake8-comprehensions: 3.14.0-1
+python3-flake8-deprecated: 2.2.1-1
+python3-flake8-docstrings: 1.6.0-2
+python3-flake8-import-order: 0.18.2-2
+python3-flake8-quotes: 3.4.0-1
+python3-pip: 24.0+dfsg-1ubuntu1.3
+python3-pytest-cov: 4.1.0-1
+python3-pytest-repeat: 0.9.3-1
+python3-pytest-rerunfailures: 12.0-1
+python3-rosdep: 0.26.0-1
+python3-vcs2l: 1.1.7-1
+ros-build-essential: 1.0.1
+ros-jazzy-desktop: 0.11.0-1noble.20260412.072512
+ros-jazzy-plotjuggler: 3.15.0-1noble.20260412.044616
+ros-jazzy-rmw-cyclonedds-cpp: 2.2.3-1noble.20260412.033317
+wget: 1.21.4-1ubuntu4.1

--- a/ansible/vars/locked-versions-jazzy-arm64.yaml
+++ b/ansible/vars/locked-versions-jazzy-arm64.yaml
@@ -1,0 +1,35 @@
+# Dependency Version Lockfile
+# ROS Distro: jazzy
+# Platform: arm64
+#
+# Versions are empty by default.
+# Run `ROS_DISTRO=jazzy ./ansible/scripts/generate_ansible_lockfile.sh` to fill in versions.
+
+ccache:
+gdown:
+geographiclib-tools:
+git-lfs:
+golang:
+pipx:
+python3-bloom:
+python3-colcon-common-extensions:
+python3-colcon-mixin:
+python3-flake8-blind-except:
+python3-flake8-builtins:
+python3-flake8-class-newline:
+python3-flake8-comprehensions:
+python3-flake8-deprecated:
+python3-flake8-docstrings:
+python3-flake8-import-order:
+python3-flake8-quotes:
+python3-pip:
+python3-pytest-cov:
+python3-pytest-repeat:
+python3-pytest-rerunfailures:
+python3-rosdep:
+python3-vcs2l:
+ros-build-essential:
+ros-jazzy-desktop:
+ros-jazzy-plotjuggler:
+ros-jazzy-rmw-cyclonedds-cpp:
+wget:


### PR DESCRIPTION
Staging PR for autowarefoundation/autoware#6934 — validates the forward-port (universe.yaml/--locked -> install_dev_env.yaml/use_locked_versions) on fork CI before the public PR branch is updated.

## What changed

- Cherry-picked `allow_downgrade` flag and ros-apt-source skip logic from the upstream draft so apt does not fail on already-installed packages at a newer version.
- Re-placed the `version_lock` role with `lockfile_path` auto-resolve defaults so callers do not need to supply an explicit path when using the conventional layout.
- Registered `install_dev_env.yaml` as the entry-point so the role is exercised by the standard developer setup flow.
- Updated README to document `use_locked_versions` and `lockfile_path` variables.
- Added generated lockfiles for the package-combination matrix entries that succeeded in local smoke runs.

## Verification

- Pre-commit hooks passed on all changed files.
- Ansible syntax-check (`ansible-playbook --syntax-check`) passed for `install_dev_env.yaml`.
- Local dry-run with `use_locked_versions=false` (default path) completed without errors.

## Refs

- autowarefoundation/autoware#6862
