### PR TITLE
test: verify Ubicloud health-check routing (do not merge)

### DIFF
--- a/ansible-galaxy-requirements.yaml
+++ b/ansible-galaxy-requirements.yaml
@@ -1,3 +1,5 @@
 collections:
   - source: ./ansible
     type: dir
+
+# ci: ubicloud routing verification (no-op)


### PR DESCRIPTION
Temporary PR to confirm the fork's health-check docker-build jobs dispatch to ubicloud-standard-16 / -arm. Will be cancelled and closed once routing is confirmed.