### PR TITLE
ci: move Ubicloud cspell exceptions to a fork-only config file

### DIFF
--- a/.cspell.fork.json
+++ b/.cspell.fork.json
@@ -1,0 +1,8 @@
+{
+  "import": ["./.cspell.json"],
+  "ignorePaths": [
+    ".github/workflows/docker-build.yaml",
+    ".github/workflows/health-check-reusable.yaml"
+  ],
+  "words": ["ubicloud", "Ubicloud"]
+}

--- a/.cspell.json
+++ b/.cspell.json
@@ -1,4 +1,4 @@
 {
   "ignorePaths": ["ansible/vars/"],
-  "words": ["lockfiles", "runpip", "ubicloud", "Ubicloud"]
+  "words": ["lockfiles", "runpip"]
 }

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -22,6 +22,12 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/spell-check@v1
         with:
           cspell-json-url: https://raw.githubusercontent.com/autowarefoundation/autoware-spell-check-dict/main/.cspell.json
+          # youtalk fork only: imports the real .cspell.json and additionally
+          # ignores the Ubicloud-routing workflow files. Kept in a separate
+          # file (rather than editing .cspell.json's ignorePaths/words
+          # directly) so this fork-only setting never conflicts with PRs
+          # staged from upstream, which touch .cspell.json's word list.
+          local-cspell-json: .cspell.fork.json
           dict-packages: |
             https://github.com/autowarefoundation/autoware-spell-check-dict
             https://github.com/tier4/cspell-dicts


### PR DESCRIPTION
## Description

#226 allowlisted `ubicloud`/`Ubicloud` directly in `.cspell.json`'s `words` array to fix `spell-check-differential` on the two workflow files that the Ubicloud-routing commit (df05ba7) touches. That works for spell-check, but it has a side effect: `.cspell.json`'s word list is exactly the kind of file a PR staged from upstream is likely to also touch (adding a new technical term), and when both this fork's `main` and a staged branch modify the same line of a 4-line JSON array, Git cannot auto-merge it. That is not a hypothetical — it happened live while staging PR #225: after #226 merged, GitHub could no longer compute a merge ref for #225, and `pull_request`-triggered CI stopped dispatching entirely for that PR (confirmed via `gh run list`, zero new runs for the new head SHA, and `gh api .../pulls/225` reporting `mergeable: false`, `mergeable_state: "dirty"`).

This PR reverts `.cspell.json` to match upstream exactly and moves the fork-only exception into a new `.cspell.fork.json` (which `import`s `.cspell.json` so both are still merged), then points `spell-check-differential.yaml`'s `local-cspell-json` input at the new file. Since `.cspell.json` itself is now untouched relative to upstream, staged branches that edit its `words` array no longer collide with anything on this fork's `main`.

## How was this PR tested?

1. `git merge-tree <merge-base> <this-branch> <PR-225-head>` shows a clean merge for `.cspell.json` (no changes on this branch's side) versus one conflicting hunk before this fix.
2. Locally reproduced the composite action's dictionary-merge step (`{"import": ["./remote.cspell.json", "./local.cspell.json"]}`) by hand-inspecting `.cspell.fork.json`'s `import` of `.cspell.json`, confirming both the real word list and the fork-only `ignorePaths` entries are combined.
3. `pre-commit run prettier --files .cspell.json .cspell.fork.json` passes.