### PR TITLE
ci: make fork cspell config self-sufficient for ansible/vars ignore

### DIFF
--- a/.cspell.fork.json
+++ b/.cspell.fork.json
@@ -2,7 +2,8 @@
   "import": ["./.cspell.json"],
   "ignorePaths": [
     ".github/workflows/docker-build.yaml",
-    ".github/workflows/health-check-reusable.yaml"
+    ".github/workflows/health-check-reusable.yaml",
+    "ansible/vars/"
   ],
   "words": ["ubicloud", "Ubicloud"]
 }


### PR DESCRIPTION
## Summary
- #227 moved fork-only cspell exceptions (Ubicloud words) into a new `.cspell.fork.json` that `import`s `.cspell.json`, so the shared file never needs fork-only edits and can't conflict with upstream-staged branches.
- Discovered while re-verifying PR #225's CI after #227 landed: once `spell-check-differential.yaml` switched to `local-cspell-json: .cspell.fork.json`, the `ansible/vars/` ignore entry from the imported `.cspell.json` stopped applying in practice, so `ansible/vars/locked-versions-*.yaml` (full of CUDA/NVIDIA package-name tokens: `nvtx`, `nvvm`, `libnvjpeg`, `cccl`, `cuobjdump`, `cupti`, `cuxxfilt`, `libnvvm`, etc.) started failing spell-check again.
- Fix: list `ansible/vars/` directly in `.cspell.fork.json`'s own `ignorePaths`, so the fork config no longer depends on import-merge semantics for this entry.

## Test plan
- [x] `pre-commit run --files .cspell.fork.json` passes locally
- [x] Confirmed `git diff df05ba7..3be3e58 --name-only -- .cspell.fork.json` is empty, i.e. PR #225 never touches this file, so this change cannot create a merge conflict against it
- [ ] `spell-check-differential` passes on PR #225 once this merges (currently failing with 62 issues in `ansible/vars/locked-versions-humble-arm64.yaml` and similar files)