### PR TITLE
ci: exercise the locked install path

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,9 @@
   ],
   "words": [
     "lockfiles",
-    "runpip"
+    "metapackage",
+    "runpip",
+    "selstate",
+    "showmanual"
   ]
 }

--- a/.github/workflows/health-check-ansible.yaml
+++ b/.github/workflows/health-check-ansible.yaml
@@ -50,6 +50,9 @@ jobs:
         image:
           - ubuntu:22.04
           - ubuntu:24.04
+        locked:
+          - false
+          - true
     container:
       image: ${{ matrix.image }}
     steps:
@@ -80,7 +83,7 @@ jobs:
           bash ansible/scripts/install-ansible.sh
           export PATH="$HOME/.local/bin:$PATH"
           ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
-          ansible-playbook autoware.dev_env.install_dev_env --skip-tags artifacts -v
+          ansible-playbook autoware.dev_env.install_dev_env --skip-tags artifacts -e use_locked_versions=${{ matrix.locked }} -v
 
       - name: 📊 Report installation disk footprint
         run: |
@@ -90,7 +93,7 @@ jobs:
           delta_gb=$(awk -v b="${delta}" 'BEGIN { printf "%.2f", b/1e9 }')
           echo "📦 Installation disk usage: ${delta_gb} GB"
           {
-            echo "## 📦 Installation disk usage (\`${{ matrix.image }}\`)"
+            echo "## 📦 Installation disk usage (\`${{ matrix.image }}\`, locked=${{ matrix.locked }})"
             echo ""
             echo "Root filesystem grew by **${delta_gb} GB** during the install."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate-lockfiles.yaml
+++ b/.github/workflows/validate-lockfiles.yaml
@@ -2,10 +2,20 @@ name: validate-lockfiles
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+    # Only what can change the outcome of a locked build. Deliberately narrower
+    # than ansible/** and docker/**: both READMEs and docker/examples live under
+    # those, and a docs-only PR must not trigger two cold container builds.
     paths:
-      - ansible/**
-      - ansible/vars/locked-versions-*.yaml
-      - docker/**
+      - ansible/roles/**
+      - ansible/vars/**
+      - ansible/playbooks/**
+      - docker/*.Dockerfile
+      - docker/docker-bake.hcl
       - .github/workflows/validate-lockfiles.yaml
 
 concurrency:
@@ -30,7 +40,17 @@ jobs:
       - name: Validate lockfiles (format + digest/lockfile coverage)
         run: ./ansible/scripts/validate_lockfiles.sh
 
+  # The locked base bakes below are two cold, uncached container builds. Put
+  # them behind the same opt-in label the repo already uses for its other
+  # expensive lanes (see health-check-ansible.yaml).
+  require-label:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
+    with:
+      label: run:health-check
+
   build-locked-base:
+    needs: require-label
+    if: needs.require-label.outputs.result == 'true'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/validate-lockfiles.yaml
+++ b/.github/workflows/validate-lockfiles.yaml
@@ -3,8 +3,9 @@ name: validate-lockfiles
 on:
   pull_request:
     paths:
+      - ansible/**
       - ansible/vars/locked-versions-*.yaml
-      - docker/docker-bake.hcl
+      - docker/**
       - .github/workflows/validate-lockfiles.yaml
 
 concurrency:
@@ -28,3 +29,19 @@ jobs:
 
       - name: Validate lockfiles (format + digest/lockfile coverage)
         run: ./ansible/scripts/validate_lockfiles.sh
+
+  build-locked-base:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        rosdistro: [humble, jazzy]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the locked base image
+        run: USE_LOCKFILE=true ROS_DISTRO=${{ matrix.rosdistro }} docker buildx bake -f docker/docker-bake.hcl base

--- a/.github/workflows/validate-lockfiles.yaml
+++ b/.github/workflows/validate-lockfiles.yaml
@@ -7,13 +7,15 @@ on:
       - synchronize
       - reopened
       - labeled
-    # Only what can change the outcome of a locked build. Deliberately narrower
-    # than ansible/** and docker/**: both READMEs and docker/examples live under
+    # Only what can change the outcome of a locked build, plus the scripts that
+    # generate and validate the lockfiles themselves. Deliberately narrower than
+    # ansible/** and docker/**: both READMEs and docker/examples live under
     # those, and a docs-only PR must not trigger two cold container builds.
     paths:
       - ansible/roles/**
       - ansible/vars/**
       - ansible/playbooks/**
+      - ansible/scripts/**
       - docker/*.Dockerfile
       - docker/docker-bake.hcl
       - .github/workflows/validate-lockfiles.yaml

--- a/ansible/playbooks/install_image_deps.yaml
+++ b/ansible/playbooks/install_image_deps.yaml
@@ -24,6 +24,13 @@
       when: use_locked_versions | default(false) | bool
       tags: [always]
 
+    - name: Reconcile installed packages to the ROS snapshot (locked mode)
+      ansible.builtin.import_role:
+        name: autoware.dev_env.version_lock
+        tasks_from: reconcile
+      when: use_locked_versions | default(false) | bool
+      tags: [always]
+
   roles:
     - role: autoware.dev_env.rmw_implementation
       tags: [base, core, universe, rmw]

--- a/ansible/playbooks/install_rmw.yaml
+++ b/ansible/playbooks/install_rmw.yaml
@@ -18,5 +18,20 @@
         tasks_from: snapshot_source
       when: use_locked_versions | default(false) | bool
       tags: [always]
+
+    - name: Reconcile installed packages to the ROS snapshot (locked mode)
+      ansible.builtin.import_role:
+        name: autoware.dev_env.version_lock
+        tasks_from: reconcile
+      when: use_locked_versions | default(false) | bool
+      tags: [always]
   roles:
     - role: autoware.dev_env.rmw_implementation
+
+  post_tasks:
+    - name: Verify installed versions match the lockfile (locked mode)
+      ansible.builtin.import_role:
+        name: autoware.dev_env.version_lock
+        tasks_from: verify
+      when: use_locked_versions | default(false) | bool
+      tags: [always]

--- a/ansible/roles/artifacts/README.md
+++ b/ansible/roles/artifacts/README.md
@@ -2,7 +2,7 @@
 
 The Autoware perception stack uses models for inference. These models are downloaded by running `ansible-playbook autoware.dev_env.install_dev_env --tags artifacts`.
 
-The models are hosted on [Hugging Face](https://huggingface.co/AutowareFoundation) under the `AutowareFoundation` organization. Models that have not been migrated yet are still hosted by Web.Auto.
+The models are hosted on [Hugging Face](https://huggingface.co/AutowareFoundation) under the `AutowareFoundation` organization. `diffusion_planner` and `tensorrt_vad` have not been migrated yet and are still hosted by Web.Auto.
 
 Default `data_dir` location is `~/autoware_data/ml_models` (part of the asset-typed `~/autoware_data/` layout: `assets/`, `maps/`, `ml_models/`, `recordings/`, `scenarios/`).
 
@@ -68,7 +68,7 @@ This step should be repeated when a new playbook is added.
 ansible-playbook autoware.dev_env.install_dev_env --tags artifacts -e "data_dir=$HOME/autoware_data/ml_models" --ask-become-pass
 ```
 
-This will download and extract the artifacts to the specified directory. Files fetched with `get_url` are validated against checksums pinned in this role. Model bundles fetched from Hugging Face are pinned to a version tag instead; their integrity relies on the Hub and the transport, not on checksums pinned here.
+This will download the artifacts to the specified directory. Files fetched with `get_url` are validated against checksums pinned in this role. Model bundles fetched from Hugging Face are pinned to a version tag instead; their integrity relies on the Hub and the transport, not on checksums pinned here.
 
 ### Migrating from the legacy layout
 

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -1,22 +1,18 @@
 # yabloc_pose_initializer
-- name: Create yabloc_pose_initializer directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/yabloc_pose_initializer"
-    mode: "755"
-    state: directory
-
-- name: Download yabloc_pose_initializer/resources.tar.gz
-  become: true
-  ansible.builtin.get_url:
-    url: https://autoware-files.s3.us-west-2.amazonaws.com/models/yabloc/136_road-segmentation-adas-0001/resources.tar.gz
-    dest: "{{ data_dir }}/yabloc_pose_initializer/resources.tar.gz"
-    mode: "644"
-    checksum: sha256:1f660e15f95074bade32b1f80dbf618e9cee1f0b9f76d3f4671cb9be7f56eb3a
-
-- name: Extract yabloc_pose_initializer/resources.tar.gz
-  ansible.builtin.unarchive:
-    src: "{{ data_dir }}/yabloc_pose_initializer/resources.tar.gz"
-    dest: "{{ data_dir }}/yabloc_pose_initializer/"
+# v0.1 is the complete upstream PINTO export, the same file set the old archive delivered. Pruning it to the
+# files the node can actually use (tag v1.0) is a separate follow-up.
+- name: Download yabloc_pose_initializer model bundle ({{ revision }})
+  vars:
+    revision: v0.1
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/yabloc_pose_initializer
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/yabloc_pose_initializer"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
 # bevfusion
 - name: Download bevfusion model bundle ({{ revision }})
@@ -47,24 +43,18 @@
   changed_when: false
 
 # bevdet
-- name: Create tensorrt_bevdet directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/tensorrt_bevdet"
-    mode: "755"
-    state: directory
-
-- name: Download tensorrt_bevdet/tensorrt_bevdet.tar.gz
-  become: true
-  ansible.builtin.get_url:
-    url: https://autoware-files.s3.us-west-2.amazonaws.com/models/tensorrt_bevdet.tar.gz
-    dest: "{{ data_dir }}/tensorrt_bevdet/tensorrt_bevdet.tar.gz"
-    mode: "644"
-    checksum: sha256:c7d16ad395e949e7a654ab511fb3294135553f92c50f2595e63a1b3e0d142c6a
-
-- name: Extract tensorrt_bevdet/tensorrt_bevdet.tar.gz
-  ansible.builtin.unarchive:
-    src: "{{ data_dir }}/tensorrt_bevdet/tensorrt_bevdet.tar.gz"
-    dest: "{{ data_dir }}/tensorrt_bevdet/"
+- name: Download tensorrt_bevdet model bundle ({{ revision }})
+  vars:
+    revision: v1.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/tensorrt_bevdet
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/tensorrt_bevdet"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
 # image_projection_based_fusion
 - name: Download image_projection_based_fusion model bundle ({{ revision }})
@@ -81,35 +71,18 @@
   changed_when: false
 
 # lidar_apollo_instance_segmentation
-- name: Create lidar_apollo_instance_segmentation directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/lidar_apollo_instance_segmentation"
-    mode: "755"
-    state: directory
-
-- name: Download lidar_apollo_instance_segmentation/vlp-16.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/lidar_apollo_instance_segmentation/vlp-16.onnx
-    dest: "{{ data_dir }}/lidar_apollo_instance_segmentation/vlp-16.onnx"
-    mode: "644"
-    checksum: sha256:eec521ebad7553d0ea2c90472a293aecb7499ab592632f0e100481c8196eb421
-
-- name: Download lidar_apollo_instance_segmentation/hdl-64.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/lidar_apollo_instance_segmentation/hdl-64.onnx
-    dest: "{{ data_dir }}/lidar_apollo_instance_segmentation/hdl-64.onnx"
-    mode: "644"
-    checksum: sha256:86348d8c4bced750f54288b01cc471c0d4f1ec9c693466169ef19413731e6ecc
-
-- name: Download lidar_apollo_instance_segmentation/vls-128.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/lidar_apollo_instance_segmentation/vls-128.onnx
-    dest: "{{ data_dir }}/lidar_apollo_instance_segmentation/vls-128.onnx"
-    mode: "644"
-    checksum: sha256:95ef950bb694bd6de91b7e47f5d191d557e92a7f5e2a6bdf655a8b5eed4075cc
+- name: Download lidar_apollo_instance_segmentation model bundle ({{ revision }})
+  vars:
+    revision: v1.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/lidar_apollo_instance_segmentation
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/lidar_apollo_instance_segmentation"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
 # lidar_centerpoint
 - name: Download lidar_centerpoint model bundle ({{ revision }})

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -127,28 +127,6 @@
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
   changed_when: false
 
-# tensorrt_rtmdet
-- name: Create tensorrt_rtmdet directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/tensorrt_rtmdet"
-    mode: "755"
-    state: directory
-
-- name: Download tensorrt_rtmdet_onnx_models.tar.gz
-  become: true
-  ansible.builtin.get_url:
-    url: https://autoware-files.s3.us-west-2.amazonaws.com/models/tensorrt_rtmdet_onnx_models.tar.gz
-    dest: "{{ data_dir }}/tensorrt_rtmdet/tensorrt_rtmdet_onnx_models.tar.gz"
-    mode: "644"
-    checksum: sha256:eaf6fe9caf1b4a0211dc3b0f4068b1fd6c1d35fe1582cc2aed95b8ed9468c598
-
-- name: Extract tensorrt_rtmdet_onnx_models.tar.gz
-  ansible.builtin.unarchive:
-    src: "{{ data_dir }}/tensorrt_rtmdet/tensorrt_rtmdet_onnx_models.tar.gz"
-    dest: "{{ data_dir }}/tensorrt_rtmdet/"
-    extra_opts:
-      - --strip-components=1 # Removes the top-level folder during extraction
-
 # traffic_light_classifier
 - name: Download traffic_light_classifier model bundle ({{ revision }})
   vars:

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -140,84 +140,19 @@
   changed_when: false
 
 # tensorrt_yolox
-- name: Create tensorrt_yolox directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/tensorrt_yolox"
-    mode: "755"
-    state: directory
-
-- name: Download tensorrt_yolox/yolox-tiny.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/yolox-tiny.onnx
-    dest: "{{ data_dir }}/tensorrt_yolox/yolox-tiny.onnx"
-    mode: "644"
-    checksum: sha256:471a665f4243e654dff62578394e508db22ee29fe65d9e389dfc3b0f2dee1255
-
-- name: Download tensorrt_yolox/yolox-sPlus-opt.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/yolox-sPlus-opt.onnx
-    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt.onnx"
-    mode: "644"
-    checksum: sha256:36b0832177b01e6b278e00c7369f1de71e616c36261cbae50f0753d41289da01
-
-- name: Download tensorrt_yolox/yolox-sPlus-opt.EntropyV2-calibration.table
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/yolox-sPlus-opt.EntropyV2-calibration.table
-    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt.EntropyV2-calibration.table"
-    mode: "644"
-    checksum: sha256:b9e9d7da33342262ccaea4469b4d02b8abb32b6d7bf737f9e0883fece1b8f580
-
-- name: Download tensorrt_yolox/yolox-sPlus-T4-960x960-pseudo-finetune.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/object_detection_yolox_s/v1/yolox-sPlus-T4-960x960-pseudo-finetune.onnx
-    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-T4-960x960-pseudo-finetune.onnx"
-    mode: "644"
-    checksum: sha256:f5054e8a890c3be86dc1b4b89a5a36fb2279d4f6110b0159e793be062641bf65
-
-- name: Download tensorrt_yolox/yolox-sPlus-T4-960x960-pseudo-finetune.EntropyV2-calibration.table
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/object_detection_yolox_s/v1/yolox-sPlus-T4-960x960-pseudo-finetune.EntropyV2-calibration.table
-    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-T4-960x960-pseudo-finetune.EntropyV2-calibration.table"
-    mode: "644"
-    checksum: sha256:cc378d327db5616b0b3a4d077bf37100c25a50ecd22d2b542f54098da100f34c
-
-- name: Download tensorrt_yolox/label.txt
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/label.txt
-    dest: "{{ data_dir }}/tensorrt_yolox/label.txt"
-    mode: "644"
-    checksum: sha256:3540a365bfd6d8afb1b5d8df4ec47f82cb984760d3270c9b41dbbb3422d09a0c
-
-# cspell: ignore semseg
-- name: Download tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/object_detection_semseg_yolox_s/v1/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx
-    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx"
-    mode: "644"
-    checksum: sha256:73b3812432cedf65cebf02ca4cb630542fc3b1671c4c0fbf7cee50fa38e416a8
-
-- name: Download tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.EntropyV2-calibration.table
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/object_detection_semseg_yolox_s/v1/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.EntropyV2-calibration.table
-    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.EntropyV2-calibration.table"
-    mode: "644"
-    checksum: sha256:28cd6524d4bcdb2809592a225d28330433e58dc02c92169ea555b44c1a51a584
-
-- name: Download tensorrt_yolox/semseg_color_map.csv
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/object_detection_semseg_yolox_s/v1/semseg_color_map.csv
-    dest: "{{ data_dir }}/tensorrt_yolox/semseg_color_map.csv"
-    mode: "644"
-    checksum: sha256:3d93ca05f31b63424d7d7246a01a2365953705a0ed3323ba5b6fddd744a4bfea
+# Includes the whole_image_traffic_light_detector models (source tl_detector_yolox_s/v1).
+- name: Download tensorrt_yolox model bundle ({{ revision }})
+  vars:
+    revision: v1.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/tensorrt_yolox
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/tensorrt_yolox"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
 # tensorrt_rtmdet
 - name: Create tensorrt_rtmdet directory inside {{ data_dir }}
@@ -241,117 +176,20 @@
     extra_opts:
       - --strip-components=1 # Removes the top-level folder during extraction
 
-# tensorrt_yolox for whole_image_traffic_light_detector
-- name: Download tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/tl_detector_yolox_s/v1/yolox_s_car_ped_tl_detector_960_960_batch_1.onnx
-    dest: "{{ data_dir }}/tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.onnx"
-    mode: "644"
-    checksum: sha256:0b8478553f2f0374a1236e65f669f11335b1fea7756ca7bcdfcf9646657ed594
-
-- name: Download tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.EntropyV2-calibration.table
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/tl_detector_yolox_s/v1/yolox_s_car_ped_tl_detector_960_960_batch_1.EntropyV2-calibration.table
-    dest: "{{ data_dir }}/tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.EntropyV2-calibration.table"
-    mode: "644"
-    checksum: sha256:690cff409519aca26f4ec0fc56ed35d9aa23ee1c18d6205c43469ae06e2f4e02
-
-- name: Download tensorrt/car_ped_tl_detector_labels.txt
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/tl_detector_yolox_s/v1/car_ped_tl_detector_labels.txt
-    dest: "{{ data_dir }}/tensorrt_yolox/car_ped_tl_detector_labels.txt"
-    mode: "644"
-    checksum: sha256:a2a91f5fe9c2e68e3e3647a272bb9bb25cd07631a1990a3fb15efddce7691131
-
 # traffic_light_classifier
-- name: Create traffic_light_classifier directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/traffic_light_classifier"
-    mode: "755"
-    state: directory
+- name: Download traffic_light_classifier model bundle ({{ revision }})
+  vars:
+    revision: v4.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/traffic_light_classifier
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/traffic_light_classifier"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
-- name: Download traffic_light_classifier/traffic_light_classifier_mobilenetv2_batch_1.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/traffic_light_classifier/v4/traffic_light_classifier_mobilenetv2_batch_1.onnx
-    dest: "{{ data_dir }}/traffic_light_classifier/traffic_light_classifier_mobilenetv2_batch_1.onnx"
-    mode: "644"
-    checksum: sha256:455b71b3b20d3a96aa0e49f32714ba50421f668a2f9b9907c30b1346ac8a3703
-
-- name: Download traffic_light_classifier/traffic_light_classifier_mobilenetv2_batch_4.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/traffic_light_classifier/v4/traffic_light_classifier_mobilenetv2_batch_4.onnx
-    dest: "{{ data_dir }}/traffic_light_classifier/traffic_light_classifier_mobilenetv2_batch_4.onnx"
-    mode: "644"
-    checksum: sha256:41bb79a23a4ac57956adb8e9cb3904420db1b0cd032e97b670cc4f8b174ae3fe
-
-- name: Download traffic_light_classifier/traffic_light_classifier_mobilenetv2_batch_6.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/traffic_light_classifier/v4/traffic_light_classifier_mobilenetv2_batch_6.onnx
-    dest: "{{ data_dir }}/traffic_light_classifier/traffic_light_classifier_mobilenetv2_batch_6.onnx"
-    mode: "644"
-    checksum: sha256:e4792eed6a46fdbd02be2f3a4f1ce91f36fa77698493caf3102e445178c0f058
-
-- name: Download traffic_light_classifier/ped_traffic_light_classifier_mobilenetv2_batch_1.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/traffic_light_classifier/v4/ped_traffic_light_classifier_mobilenetv2_batch_1.onnx
-    dest: "{{ data_dir }}/traffic_light_classifier/ped_traffic_light_classifier_mobilenetv2_batch_1.onnx"
-    mode: "644"
-    checksum: sha256:b52632fee96d1bc99922e743335ebfd49d6a0645c8a04e615f156e38661add24
-
-- name: Download traffic_light_classifier/ped_traffic_light_classifier_mobilenetv2_batch_4.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/traffic_light_classifier/v4/ped_traffic_light_classifier_mobilenetv2_batch_4.onnx
-    dest: "{{ data_dir }}/traffic_light_classifier/ped_traffic_light_classifier_mobilenetv2_batch_4.onnx"
-    mode: "644"
-    checksum: sha256:ef0a3052857cdc6f380da524560548b40e9e46f876cccf3cd0cb40ccddae9892
-
-- name: Download traffic_light_classifier/ped_traffic_light_classifier_mobilenetv2_batch_6.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/traffic_light_classifier/v4/ped_traffic_light_classifier_mobilenetv2_batch_6.onnx
-    dest: "{{ data_dir }}/traffic_light_classifier/ped_traffic_light_classifier_mobilenetv2_batch_6.onnx"
-    mode: "644"
-    checksum: sha256:b56700551254afa985916d03b74372ebc675f2d9b76ee0e39c46e88c37744a4f
-
-- name: Download traffic_light_classifier/lamp_labels.txt
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/traffic_light_classifier/v4/lamp_labels.txt
-    dest: "{{ data_dir }}/traffic_light_classifier/lamp_labels.txt"
-    mode: "644"
-    checksum: sha256:1a5a49eeec5593963eab8d70f48b8a01bfb07e753e9688eb1510ad26e803579d
-
-- name: Download traffic_light_classifier/lamp_labels_ped.txt
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/traffic_light_classifier/v4/lamp_labels_ped.txt
-    dest: "{{ data_dir }}/traffic_light_classifier/lamp_labels_ped.txt"
-    mode: "644"
-    checksum: sha256:5427e1b7c2e33acd9565ede29e77992c38137bcf7d7074c73ebbc38080c6bcac
-
-# cspell: ignore comlops
-- name: Download traffic_light_classifier/traffic_light_lamp_recognizer_comlops.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/traffic_light_classifier/v4/traffic_light_lamp_recognizer_comlops.onnx
-    dest: "{{ data_dir }}/traffic_light_classifier/traffic_light_lamp_recognizer_comlops.onnx"
-    mode: "644"
-    checksum: sha256:300af04a5893961195a9b7ffd9d80364280f328a6dc549f9b1e05d428d96d2e5
-- name: Download traffic_light_classifier/v4/lamp_recognizer_ml.param.yaml
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/traffic_light_classifier/v4/lamp_recognizer_ml.param.yaml
-    dest: "{{ data_dir }}/traffic_light_classifier/lamp_recognizer_ml.param.yaml"
-    mode: "644"
-    checksum: sha256:80d92943a036ac454aac200a3be83d693dacab924c869f556ef09f70deab097a
 # diffusion_planner
 - name: Create diffusion_planner directory inside {{ data_dir }}
   ansible.builtin.file:
@@ -518,43 +356,18 @@
     checksum: sha256:03d3187fed3c70f761456afc2e93e18c1765113b1c1580ffa78ab42b10dbd179
 
 # traffic_light_fine_detector
-- name: Create traffic_light_fine_detector directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/traffic_light_fine_detector"
-    mode: "755"
-    state: directory
-
-- name: Download traffic_light_fine_detector/tlr_car_ped_yolox_s_batch_1.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/tlr_yolox_s/v3/tlr_car_ped_yolox_s_batch_1.onnx
-    dest: "{{ data_dir }}/traffic_light_fine_detector/tlr_car_ped_yolox_s_batch_1.onnx"
-    mode: "644"
-    checksum: sha256:1ad633066a1195006f4709f8fa07800dd65a74a814b3efb4c99bcc5a1a7962f6
-
-- name: Download traffic_light_fine_detector/tlr_car_ped_yolox_s_batch_4.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/tlr_yolox_s/v3/tlr_car_ped_yolox_s_batch_4.onnx
-    dest: "{{ data_dir }}/traffic_light_fine_detector/tlr_car_ped_yolox_s_batch_4.onnx"
-    mode: "644"
-    checksum: sha256:cf93eb1e1a97aefc6edd0c0c4d77c7f5fc2aa1e81e3c5c9cd49d976173d03a04
-
-- name: Download traffic_light_fine_detector/tlr_car_ped_yolox_s_batch_6.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/tlr_yolox_s/v3/tlr_car_ped_yolox_s_batch_6.onnx
-    dest: "{{ data_dir }}/traffic_light_fine_detector/tlr_car_ped_yolox_s_batch_6.onnx"
-    mode: "644"
-    checksum: sha256:0b05a89fb30f1f92c6ec687d48e8ceda4da6f81cbd82d8a102d168753a6cedb6
-
-- name: Download traffic_light_fine_detector/tlr_labels.txt
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/tlr_yolox_s/v3/tlr_labels.txt
-    dest: "{{ data_dir }}/traffic_light_fine_detector/tlr_labels.txt"
-    mode: "644"
-    checksum: sha256:a2a91f5fe9c2e68e3e3647a272bb9bb25cd07631a1990a3fb15efddce7691131
+- name: Download traffic_light_fine_detector model bundle ({{ revision }})
+  vars:
+    revision: v3.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/traffic_light_fine_detector
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/traffic_light_fine_detector"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
 # simpl_prediction
 - name: Download simpl_prediction model bundle ({{ revision }})

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -26,6 +26,28 @@
   register: cuda__dash_case_cuda_version
   changed_when: false
 
+# The CUDA packages carry version-suffixed names, so a closure from another
+# generation does not collide with them — it simply fails to cover them, and the
+# install proceeds against whatever the accretive NVIDIA repo serves that day.
+# verify.yaml cannot catch that either: it reports drift only for lockfile keys
+# that are installed, and the other generation's keys never are.
+- name: Assert the locked NVIDIA closure covers this cuda_version
+  ansible.builtin.assert:
+    that:
+      - ("cuda-minimal-build-" ~ cuda__dash_case_cuda_version.stdout) in (locked_packages.nvidia_pins | default({}))
+    fail_msg: >-
+      Locked mode: nvidia_pins has no
+      cuda-*-{{ cuda__dash_case_cuda_version.stdout }} entries, so the CUDA
+      closure this run installs would not be frozen. Point nvidia_lockfile_path
+      at a closure recorded for cuda_version={{ cuda_version }}, or drop the
+      cuda_version override.
+    quiet: true
+  # Deliberately not also gated on nvidia_pins being non-empty: an empty
+  # closure covers nothing, which is exactly when this assert is needed.
+  # locked_packages is always loaded first — every playbook that reaches this
+  # role imports version_lock as a pre_task tagged 'always'.
+  when: use_locked_versions | default(false) | bool
+
 - name: Install CUDA devel libraries except for cuda-drivers
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/qt5ct_setup/tasks/main.yml
+++ b/ansible/roles/qt5ct_setup/tasks/main.yml
@@ -1,13 +1,26 @@
+# cspell:ignore Xsession
+# state: latest so an already-installed package is converged onto the pinned
+# version in locked mode; state: present would leave whatever the machine came
+# with, and the lockfile verification would then fail on a package no task
+# would ever move. state: latest resolves against the apt index, so refresh it
+# first: without update_cache a standalone `--tags qt5ct_setup` run would be an
+# unconditional upgrade against a possibly stale index.
 - name: Install qt5ct
   ansible.builtin.apt:
     name: qt5ct
-    state: present
+    state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
+    update_cache: true
+    cache_valid_time: 3600
   become: true
 
 - name: Install rsync
-  ansible.builtin.package:
+  ansible.builtin.apt:
     name: rsync
-    state: present
+    state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
+    update_cache: true
+    cache_valid_time: 3600
   become: true
 
 - name: Remove qt5ct from auto-start

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -38,6 +38,12 @@
   ansible.builtin.import_tasks: snapshot_source.yaml
   when: use_locked_versions | default(false) | bool
 
+- name: Reconcile installed packages to the ROS snapshot (locked mode)
+  ansible.builtin.import_role:
+    name: autoware.dev_env.version_lock
+    tasks_from: reconcile
+  when: use_locked_versions | default(false) | bool
+
 - name: Hold check of ros-{{ rosdistro + '-' + ros2_installation_type }}
   ansible.builtin.command: apt-mark showhold
   register: ros2_held_ros_packages

--- a/ansible/roles/ros2_dev_tools/README.md
+++ b/ansible/roles/ros2_dev_tools/README.md
@@ -1,6 +1,6 @@
 # ros2_dev_tools
 
-This role installs ROS 2 development tools following [this page](https://docs.ros.org/en/humble/Installation/Ubuntu-Development-Setup.html).
+This role installs ROS 2 development tools following [this page](https://docs.ros.org/en/humble/Installation/Alternatives/Ubuntu-Development-Setup.html).
 
 ## Inputs
 
@@ -9,7 +9,7 @@ None.
 ## Manual Installation
 
 ```bash
-# Taken from https://docs.ros.org/en/humble/Installation/Ubuntu-Development-Setup.html
+# Taken from https://docs.ros.org/en/humble/Installation/Alternatives/Ubuntu-Development-Setup.html
 sudo apt update && sudo apt install -y \
   python3-colcon-mixin \
   python3-flake8-docstrings \
@@ -24,7 +24,10 @@ sudo apt update && sudo apt install -y \
   python3-flake8-quotes \
   python3-pytest-repeat \
   python3-pytest-rerunfailures \
-  ros-build-essential \
+  build-essential \
+  cmake \
+  git \
+  python3-setuptools \
   python3-bloom \
   python3-colcon-common-extensions \
   python3-colcon-mixin \

--- a/ansible/roles/ros2_dev_tools/tasks/main.yaml
+++ b/ansible/roles/ros2_dev_tools/tasks/main.yaml
@@ -15,7 +15,14 @@
       - python3-flake8-quotes
       - python3-pytest-repeat
       - python3-pytest-rerunfailures
-      - ros-build-essential # from ros-dev-tools
+      # ros-build-essential's contents, inlined: the metapackage is served only
+      # by the rolling packages.ros.org repo and is absent from snapshots.ros.org,
+      # so locked mode cannot resolve it. Inlining also lets apt_pins freeze the
+      # actual tools. (python3 is omitted: it is always present.)
+      - build-essential
+      - cmake
+      - git
+      - python3-setuptools
       - python3-bloom # from ros-dev-tools
       - python3-colcon-common-extensions # from ros-dev-tools
       - python3-colcon-mixin # from ros-dev-tools

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -1,3 +1,28 @@
+# The TensorRT packages carry unversioned names, so a lockfile whose closure is
+# from another CUDA generation pins the very names installed below. Its pin and
+# the 1001 Ansible's apt module gives its own pkg=version request tie, apt keeps
+# the higher version, and the install fails with a bare "no available
+# installation candidate" that names neither the pin nor the lockfile.
+- name: Assert the locked NVIDIA closure matches tensorrt_version
+  ansible.builtin.assert:
+    that:
+      - tensorrt__locked_libnvinfer10 == tensorrt_version
+    fail_msg: >-
+      Locked mode: the lockfile pins libnvinfer10 to
+      {{ tensorrt__locked_libnvinfer10 }}, but this run requests
+      tensorrt_version={{ tensorrt_version }}. Point nvidia_lockfile_path at a
+      closure recorded for this TensorRT version, or drop the tensorrt_version
+      override.
+    quiet: true
+  vars:
+    # "(none)" rather than skipping the assert: a closure with no libnvinfer10
+    # entry leaves the packages below unfrozen, which is exactly the case this
+    # assert exists to catch. locked_packages is always loaded first — every
+    # playbook that reaches this role imports version_lock as a pre_task
+    # tagged 'always'.
+    tensorrt__locked_libnvinfer10: "{{ (locked_packages.nvidia_pins | default({})).libnvinfer10 | default('(none)') }}"
+  when: use_locked_versions | default(false) | bool
+
 - name: Install TensorRT
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -22,6 +22,44 @@ To use a custom lockfile, override `lockfile_path`:
 ansible-playbook autoware.dev_env.install_dev_env --extra-vars "use_locked_versions=true lockfile_path=/path/to/my-lockfile.yaml" --ask-become-pass
 ```
 
+#### Overriding only the NVIDIA closure
+
+`(rosdistro, arch)` does not identify the CUDA/TensorRT closure. That closure is a function of `(cuda_repo_distro, cuda_version, tensorrt_version, arch)`, and the `cuda` and `tensorrt` roles let a consumer override all four — so `locked-versions-<rosdistro>-<arch>.yaml` can only carry the generation those roles default to for that distro (CUDA 13.0 on 24.04, 12.8 on 22.04). A consumer that overrides `cuda_version` or `tensorrt_version` must supply the matching closure through `nvidia_lockfile_path`:
+
+```bash
+ansible-playbook autoware.dev_env.install_nvidia \
+  --extra-vars "rosdistro=jazzy use_locked_versions=true cuda_version=12.8 tensorrt_version=10.8.0.43-1+cuda12.8" \
+  --extra-vars "nvidia_lockfile_path=/path/to/locked-nvidia-ubuntu2404-cuda12.8-amd64.yaml"
+```
+
+`rosdistro` is needed even though the closure does not depend on it: unlike `install_dev_env`, the `install_nvidia` playbook does not define it, and `lockfile_path` — loaded before `nvidia_lockfile_path` is consulted — interpolates it. (`base-cuda.Dockerfile` passes it, which is why the Docker path needs no such note.)
+
+The file needs only a top-level `nvidia_pins` mapping, in the same format as a lockfile's, and is produced the same way (`emit_nvidia_pins.py`, see below). It **replaces** `nvidia_pins` rather than merging into it, and `verify.yaml` then checks the substituted closure, so the pins stay exact and the freeze is unchanged — only the source file moves.
+
+Leaving `nvidia_lockfile_path` empty while overriding a version is not silently tolerated: the `cuda` role fails when no `cuda-*-<version>` entry covers this run, and the `tensorrt` role fails when the pinned `libnvinfer10` disagrees with `tensorrt_version`. Without those guards the CUDA half would install unfrozen (its version-suffixed names simply are not in the closure, and `verify.yaml` reports drift only for keys that are installed) and the TensorRT half would fail with an unattributable `no available installation candidate`.
+
+### Snapshot reconcile
+
+In locked mode the role does not only pin future installs: right after the
+dated snapshot source is configured, a reconcile step walks every **already
+installed** package that the snapshot serves at a different version back to
+the snapshot's version (`tasks/reconcile.yaml`, driven by
+`files/list_ros_snapshot_drift.py`). This matters most for Docker builds: the
+digest-pinned `ros:<distro>-ros-base` base image is built from a floating tag
+and is usually newer than `ros_snapshot_date`, so without the reconcile the
+final image would carry a hybrid ROS closure. The step is scoped to packages
+whose apt candidate originates from `snapshots.ros.org`; Ubuntu-archive
+packages are left at the digest-frozen base-image state plus explicit
+`apt_pins`. After all roles run, verification asserts the whole installed
+closure matches the snapshot (`tasks/verify.yaml`).
+
+Packages under an `apt-mark hold` are **skipped** by both the reconcile and
+the closure assert, and listed in the play output. A hold is an explicit
+operator decision to keep one package where it is; apt refuses to act on a
+held package unless told to override the hold, so including one would abort
+the entire reconcile. The trade-off is that a held package is outside the
+freeze — release the hold if you want locked mode to govern it.
+
 ## Generating lockfiles
 
 On a machine already provisioned by `install_dev_env`, run:
@@ -41,7 +79,7 @@ tell an NVIDIA-repo package from an Ubuntu-archive one. On a machine that has ju
 completed an **unlocked** `install_nvidia`, run:
 
 ```bash
-sudo apt-get update
+sudo apt-get update && sudo apt-get install -y python3-yaml   # the script imports yaml and shells out to apt-get/apt-helper/dpkg-query
 ./ansible/scripts/emit_nvidia_pins.py ansible/vars/locked-versions-<rosdistro>-<arch>.yaml
 ```
 
@@ -57,6 +95,123 @@ The two generators are order-independent on an already-filled lockfile — `gene
 preserves `nvidia_pins` and this script preserves `apt_pins`/`pip_pins` — but both must run on a
 machine provisioned from the same snapshot date. On a lockfile that has no `ros_snapshot_date` yet,
 run `generate_ansible_lockfile.sh` first; this script refuses an unfilled lockfile.
+
+The same script records a **closure-only** file for `nvidia_lockfile_path`. Given a file whose only
+top-level key is `nvidia_pins` (an empty one, or one carrying just a header comment), it fills that
+key and leaves the file with no ROS sections — so a consumer's closure never carries a
+`ros_snapshot_date` it does not own. Run it on a machine provisioned with the `cuda_version` /
+`tensorrt_version` that file is meant to describe:
+
+```bash
+printf '# NVIDIA closure for ubuntu2404 / CUDA 12.8 / amd64\nnvidia_pins: {}\n' >closure.yaml
+./ansible/scripts/emit_nvidia_pins.py closure.yaml
+```
+
+## When you add a new dependency
+
+Key insertion is the responsibility of the PR that changes a role; the
+`regenerate-lockfiles` workflow refreshes **values** of existing keys but
+never discovers new ones.
+
+| New dependency                                      | Lockfile action                                                                                                                       | Enforced by                                                               |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| ROS-repo package (`ros-*`, `python3-colcon-*`, ...) | none — `ros_snapshot_date` freezes it                                                                                                 | snapshot reconcile + closure verify                                       |
+| Ubuntu-archive package                              | add the key to `apt_pins` in **all four** lockfiles in the same PR (any current version; the next regeneration canonicalizes it)      | locked-mode verify fails listing unpinned newly-installed Ubuntu packages |
+| pip package                                         | add the key to `pip_pins` in the same PR                                                                                              | documented convention only                                                |
+| NVIDIA-repo package                                 | run `emit_nvidia_pins.py` on a machine after an unlocked `install_nvidia`; the regenerate workflow does **not** refresh `nvidia_pins` | documented convention only                                                |
+| Third-party apt repo package (PPA, vendor repo)     | no lockfile section covers it — see "What the freeze does not cover" below                                                            | nothing                                                                   |
+| Version refresh of existing keys                    | dispatch `regenerate-lockfiles.yaml` (updates lockfiles, snapshot dates, and base-image digests atomically)                           | `validate-lockfiles`                                                      |
+
+The Ubuntu-archive check's "Enforced by" only holds on a fresh host: it diffs
+`apt-mark showmanual` taken before any role runs against the same list taken
+after, so a package that is already manually installed going in — a rerun on
+a developer machine, or a Docker stage inheriting from one that installed it
+already — never shows up in the diff and slips past unchecked. Treat a green
+local run as covering only what was newly installed manual on that host, not
+as proof the lockfiles have no gaps; the check is reliable on the fresh
+containers CI builds from.
+
+A key in `apt_pins` also obliges the task that installs the package to
+**converge** it — `state: latest` with
+`allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"`, the
+idiom `ros2_dev_tools` uses. `state: present` is a no-op on an
+already-installed package, so on a pre-provisioned machine the pin would never
+be applied while the verification still fails on the mismatch, with advice the
+user cannot act on. Pin only what a task actually moves.
+
+Kernel-coupled packages (`linux-headers-*`, `linux-image-*`, `linux-modules-*`)
+are exempt from the check. `agnocast` installs `linux-headers-{{ ansible_kernel }}`
+on bare metal; its name varies per machine and changes on every kernel upgrade,
+so no static lockfile key could cover it. It is a host property, not a
+dependency of Autoware, and freezing it is neither possible nor desirable.
+
+### What the freeze does not cover
+
+The table above is not a complete inventory of what an install pulls in. Five
+categories sit outside the freeze today, and the completeness check reports
+none of them:
+
+- **Third-party apt repositories.** The check only reports packages whose
+  installed version carries `Origin: Ubuntu`, so a package from any other
+  origin passes silently. There are three live cases, all installed top-level
+  with `state: present` and covered by none of `ros_snapshot_date`,
+  `apt_pins`, `nvidia_pins`, or `pip_pins`. `agnocast` installs two packages
+  from a Launchpad PPA (`Origin: LP-PPA-...`): its heaphook package, and
+  `agnocast_kmod_package` on any non-container host. `cuda` installs the
+  `nvidia-open` driver metapackage from NVIDIA's apt repository
+  (`developer.download.nvidia.com`) when `cuda_install_drivers=true`;
+  `nvidia_pins` freezes the CUDA toolkit and TensorRT packages that role names
+  explicitly, not the driver. A locked install that runs either role is
+  therefore not fully frozen.
+- **pip/pipx-managed packages.** `pip_pins` is currently empty and no role
+  reads it. The pipx installs in `dev_tools` and `huggingface_cli`
+  (`pre-commit`, `clang-format`, `huggingface_hub`) and the Python virtual
+  environment installs in `acados` all resolve to whatever the Python package
+  index serves at install time.
+- **ROS packages the snapshot does not serve at all.** `ros_snapshot_date`
+  freezes the packages the dated snapshot carries. A `ros-*` package absent
+  from the snapshot is not frozen, and what happens to it depends on whether a
+  rolling `packages.ros.org` source is configured on the host, because
+  `ros2/tasks/main.yaml:1-2` gates the whole `ros-apt-source` block on
+  `not use_locked_versions` and `snapshot_source.yaml` writes only the snapshot
+  source:
+  - In Docker, where `ros:<distro>-ros-base` brings its own source, and on a
+    machine that previously ran unlocked, such a package **floats**: it
+    installs from rolling at the default priority 500, since the
+    `Pin: origin snapshots.ros.org` wildcard cannot apply to a package that
+    origin does not offer.
+  - On a fresh bare-metal locked run, no rolling source is ever configured,
+    so such a package is **unreachable** rather than floating.
+
+  This is not hypothetical: the noble rolling index carries 71
+  `ros-jazzy-autoware-*` names the 2026-04-13 snapshot lacks, and
+  `core.Dockerfile` deletes the `autoware_core` and `autoware_rviz_plugins`
+  `package.xml` so that the rest of `src/core` resolves them from apt instead
+  of from source. The closure verify does not report any of this either: it
+  compares against packages whose apt _candidate_ comes from the snapshot, and
+  theirs does not.
+
+- **Packages installed outside the roles.** The completeness check diffs
+  `apt-mark showmanual` across the play, so anything installed before
+  `version_lock` runs is invisible to it — including the five packages
+  `docker/base.Dockerfile` installs with a raw `apt-get` before the pin file
+  exists. Four of those five have no lockfile key at all; `pipx` has a key in
+  all four lockfiles, but the pin is not in effect for that install, so its
+  version is equally unfrozen there. Transitive Ubuntu dependencies are not
+  checked either (only top-level installs are), nor are the packages the ten
+  `rosdep install` call sites resolve.
+- **Packages outside the freeze's remit.** `unzip` is installed only by
+  `demo_artifacts`, which is `tags: [never]` and appears in no other playbook,
+  so no normal locked path converges it — while `verify.yaml` asserts every pin
+  whose package is installed regardless of which roles ran. Since `unzip` is a
+  hard `Depends` of `ubuntu-desktop`, pinning it failed a locked
+  `install_dev_env` on any desktop whose `unzip` differed from the pin, with no
+  task in the play able to fix it. It is therefore exempt via `OUT_OF_SCOPE` in
+  `check_pin_completeness.py` rather than pinned, and floats on a
+  `--tags demo_artifacts` run.
+
+These are known gaps rather than oversights: closing them means changing how
+those roles install, which is out of scope for the lockfile mechanism itself.
 
 ## Validating lockfiles
 
@@ -98,8 +253,10 @@ ros_overrides: {} # exception pins for individual ROS packages; normally empty
   otherwise both sit at priority 500 and apt would install the newer rolling build.
 - `apt_pins` covers Ubuntu-archive packages. It is rendered into `/etc/apt/preferences.d/autoware-lock`
   with `Pin-Priority: 1001`.
-- `pip_pins` covers pip/pipx-managed packages. It is consumed directly by the
-  relevant roles and is **not** rendered as APT pins.
+- `pip_pins` is the declared home for pip/pipx-managed packages. It is meant to be consumed
+  directly by the relevant roles and is **not** rendered as APT pins. It is currently `{}` in
+  every lockfile and no role reads it: `gdown`, its last consumer, was removed. See "What the
+  freeze does not cover" for the pip/pipx installs that remain unpinned.
 - `nvidia_pins` covers the CUDA/TensorRT closure from NVIDIA's apt repo, rendered into
   `/etc/apt/preferences.d/autoware-lock` with `Pin-Priority: 1001` like `apt_pins`. It is a
   separate section because NVIDIA publishes no dated snapshot to freeze against — its repo is
@@ -121,16 +278,19 @@ ros_overrides: {} # exception pins for individual ROS packages; normally empty
 
 ### Overriding a single ROS package
 
-`ros_overrides` is normally `{}` — the `ros_snapshot_date` freezes the whole ROS closure, so no
-per-package ROS pins are needed. Use it only to move **one** ROS package to a different version than
-the snapshot (for example, to pick up a security or bug fix) without advancing `ros_snapshot_date`
-for everything else. Each entry is `package: version`, where `version` is the exact APT version
-string, and **that version must be reachable from a configured APT source**.
+`ros_overrides` is normally `{}` — the `ros_snapshot_date` freezes every ROS package the snapshot
+serves, so no per-package ROS pins are needed. Use it only to move **one** ROS package to a
+different version than the snapshot (for example, to pick up a security or bug fix) without
+advancing `ros_snapshot_date` for everything else. Each entry is `package: version`, where `version`
+is the exact APT version string, and **that version must be reachable from a configured APT
+source**.
 
-This is the important constraint: in locked mode the only ROS source is the dated snapshot, which
-serves exactly one build per package, so an override to any other version resolves to nothing unless
-you also make it reachable. In practice that means pointing the whole snapshot at a later date that
-contains the build you want, and pinning that exact build so nothing else moves:
+This is the important constraint: in locked mode the dated snapshot is the only ROS source
+`version_lock` configures, and it serves exactly one build per package, so an override to any other
+version resolves to nothing unless you also make it reachable. (A `ros-*` package the snapshot does
+not carry at all is a separate case — see "What the freeze does not cover" above.) In practice that
+means pointing the whole snapshot at a later date that contains the build you want, and pinning that
+exact build so nothing else moves:
 
 ```yaml
 ros_snapshot_date: "2026-05-20" # a snapshot that actually serves the build below

--- a/ansible/roles/version_lock/defaults/main.yaml
+++ b/ansible/roles/version_lock/defaults/main.yaml
@@ -3,3 +3,11 @@ version_lock_arch_map:
   aarch64: arm64
 # lockfile_path is the published interface-contract variable; renaming would break consumers.
 lockfile_path: "{{ role_path }}/../../vars/locked-versions-{{ rosdistro }}-{{ version_lock_arch_map[ansible_architecture] | default(ansible_architecture) }}.yaml" # noqa: var-naming[no-role-prefix]
+# Optional path to a file whose nvidia_pins describe the CUDA/TensorRT closure
+# THIS run installs. That closure is a function of (cuda_repo_distro,
+# cuda_version, tensorrt_version, arch) and not of rosdistro, so
+# locked-versions-<rosdistro>-<arch>.yaml can only carry the generation the
+# cuda/tensorrt role defaults pick for that distro. A consumer overriding
+# cuda_version or tensorrt_version must point this at its own closure file.
+# Empty means: use the nvidia_pins in lockfile_path.
+nvidia_lockfile_path: "" # noqa: var-naming[no-role-prefix]

--- a/ansible/roles/version_lock/files/check_pin_completeness.py
+++ b/ansible/roles/version_lock/files/check_pin_completeness.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Filter package names to those installed from the Ubuntu archive.
+
+Reads package names (one per line) on stdin and prints the ones whose
+installed version carries a Release "Origin: Ubuntu" — i.e. packages that a
+locked install must have an apt_pins entry for. ROS-repo (Origin: ROS) and
+NVIDIA-repo packages are excluded: the dated snapshot and nvidia_pins freeze
+those. Used by the locked-mode pin-completeness check in verify.yaml.
+
+Kernel-coupled packages (linux-headers-*, linux-image-*, linux-modules-*) are
+also excluded. The agnocast role installs linux-headers-{{ ansible_kernel }}
+on bare metal, whose name varies per machine and changes on every kernel
+upgrade, so no static lockfile key could ever cover it.
+
+OUT_OF_SCOPE names a second, distinct exemption: packages a static key *could*
+cover, but that sit outside the freeze's remit. Pinning them would make
+verify.yaml fail a locked run that no role in the play can converge, since the
+verify post_task asserts every pin whose package is installed regardless of
+which roles ran. See the version_lock README for the per-package rationale.
+"""
+
+import re
+import sys
+
+import apt
+
+KERNEL_COUPLED = re.compile(r"^linux-(headers|image|modules)-")
+
+# unzip is installed by demo_artifacts alone, which is tags: [never] and in no
+# other playbook, so it converges on no normal locked path. It is also a hard
+# Depends of ubuntu-desktop, so pinning it fails a locked install_dev_env on
+# any desktop whose unzip differs from the pin, with no task able to fix it.
+OUT_OF_SCOPE = frozenset({"unzip"})
+
+
+def main() -> None:
+    names = [line.strip() for line in sys.stdin if line.strip()]
+    cache = apt.Cache()
+    for name in names:
+        if KERNEL_COUPLED.match(name) or name in OUT_OF_SCOPE:
+            continue
+        if name not in cache:
+            continue
+        pkg = cache[name]
+        if not pkg.is_installed:
+            continue
+        if any(o.origin == "Ubuntu" for o in pkg.installed.origins):
+            print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/version_lock/files/list_ros_snapshot_drift.py
+++ b/ansible/roles/version_lock/files/list_ros_snapshot_drift.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""List installed packages diverging from the dated ROS snapshot.
+
+Prints one "name=candidate_version" line for every installed package whose
+apt candidate comes from snapshots.ros.org (the dated snapshot configured in
+locked mode, pinned to priority 1001) at a version different from the one
+installed. Scoping to snapshot-origin candidates keeps the reconcile step from
+touching Ubuntu-archive packages: those are frozen by the base-image digest
+plus explicit apt_pins, and moving them would break that freeze.
+
+Packages under an `apt-mark hold` are skipped and reported on stderr instead:
+a hold is an explicit operator decision, and apt refuses to act on a held
+package unless told to override the hold, which would abort the whole
+reconcile over one package the user deliberately froze.
+
+Requires python3-apt (installed by this role's tasks/main.yaml) and an
+up-to-date apt cache.
+"""
+
+import sys
+
+import apt
+import apt_pkg
+
+SNAPSHOT_SITE = "snapshots.ros.org"
+
+
+def main() -> None:
+    cache = apt.Cache()
+    held = []
+    for pkg in cache:
+        if not pkg.is_installed or pkg.candidate is None:
+            continue
+        if pkg.candidate.version == pkg.installed.version:
+            continue
+        if not any(o.site == SNAPSHOT_SITE for o in pkg.candidate.origins):
+            continue
+        if pkg._pkg.selected_state == apt_pkg.SELSTATE_HOLD:
+            held.append(pkg.name)
+            continue
+        print(f"{pkg.name}={pkg.candidate.version}")
+    if held:
+        print(
+            "skipped (apt-mark hold): " + " ".join(sorted(held)),
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/version_lock/tasks/main.yaml
+++ b/ansible/roles/version_lock/tasks/main.yaml
@@ -14,6 +14,37 @@
       The lockfile may be an unfilled arm64 template.
   when: use_locked_versions | default(false) | bool
 
+- name: Load the consumer-supplied NVIDIA closure
+  ansible.builtin.include_vars:
+    file: "{{ nvidia_lockfile_path }}"
+    name: version_lock_nvidia
+  when:
+    - use_locked_versions | default(false) | bool
+    - nvidia_lockfile_path | length > 0
+
+- name: Assert the consumer-supplied NVIDIA closure provides nvidia_pins
+  ansible.builtin.assert:
+    that:
+      - version_lock_nvidia.nvidia_pins is defined
+      - version_lock_nvidia.nvidia_pins | length > 0
+    fail_msg: >-
+      nvidia_lockfile_path={{ nvidia_lockfile_path }} must define a non-empty
+      'nvidia_pins' mapping.
+  when:
+    - use_locked_versions | default(false) | bool
+    - nvidia_lockfile_path | length > 0
+
+# Substituted, not merged: a consumer supplies its own closure precisely because
+# it installs a different CUDA generation, so keeping the lockfile's own entries
+# would pin packages this run never installs — and, for the unversioned TensorRT
+# names, would pin them to the wrong generation.
+- name: Substitute the consumer-supplied NVIDIA closure # noqa: var-naming[no-role-prefix]
+  ansible.builtin.set_fact:
+    locked_packages: "{{ locked_packages | combine({'nvidia_pins': version_lock_nvidia.nvidia_pins}) }}"
+  when:
+    - use_locked_versions | default(false) | bool
+    - nvidia_lockfile_path | length > 0
+
 - name: Create APT version pins
   become: true
   ansible.builtin.template:
@@ -28,3 +59,29 @@
     path: /etc/apt/preferences.d/autoware-lock
     state: absent
   when: not (use_locked_versions | default(false) | bool)
+
+# Both files/list_ros_snapshot_drift.py and files/check_pin_completeness.py
+# `import apt`, so python3-apt is a declared dependency of this role, not
+# incidental bootstrap. Installing it explicitly, before the baseline below,
+# serves two purposes: it converges onto the pinned version (Ansible's apt
+# module would otherwise self-heal it at whatever apt offers), and it keeps it
+# out of the before/after diff that drives the pin-completeness check.
+- name: Install python3-apt for the version_lock scripts
+  become: true
+  ansible.builtin.apt:
+    name: python3-apt
+    state: latest
+    allow_downgrade: true
+    update_cache: true
+  when: use_locked_versions | default(false) | bool
+
+# Baseline for the pin-completeness check in verify.yaml: whatever is
+# top-level ("manual") before any role runs. Packages the play later installs
+# top-level from the Ubuntu archive must appear in apt_pins; the generator
+# only refreshes keys that already exist, so a forgotten key would otherwise
+# float silently in locked mode.
+- name: Record manually-installed packages before roles run
+  ansible.builtin.command: apt-mark showmanual
+  register: version_lock_manual_before
+  changed_when: false
+  when: use_locked_versions | default(false) | bool

--- a/ansible/roles/version_lock/tasks/reconcile.yaml
+++ b/ansible/roles/version_lock/tasks/reconcile.yaml
@@ -1,0 +1,44 @@
+# Walk every installed package that the dated ROS snapshot serves at a
+# different version back to the snapshot's version. This matters when packages
+# were installed before the snapshot source existed — above all the ROS closure
+# preinstalled in the ros:<distro>-ros-base base image, whose floating tag is
+# usually newer than the lockfile's ros_snapshot_date. Scoped to
+# snapshot-origin candidates only: a blanket dist-upgrade would also advance
+# unpinned Ubuntu-archive packages past the digest-frozen base-image state.
+# Callers import this file guarded by `when: use_locked_versions`.
+#
+# python3-apt, which the enumerator script needs, is installed by main.yaml.
+# The interpreter is named absolutely rather than as a bare `python3`: the
+# latter resolves from the invoking user's PATH, and any active venv shadows
+# the system interpreter that python3-apt installs into. Templating
+# `ansible_python_interpreter` instead would be worse — on the implicit
+# localhost these plays run against, Ansible sets it to its own sys.executable,
+# and Autoware installs Ansible with pipx (scripts/install-ansible.sh,
+# docker/base.Dockerfile), so it always points at a venv with no apt bindings.
+- name: Update apt cache so snapshot candidates are visible
+  become: true
+  ansible.builtin.apt:
+    update_cache: true
+
+- name: List installed packages diverging from the ROS snapshot
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/python3
+      - "{{ role_path }}/files/list_ros_snapshot_drift.py"
+  register: version_lock_reconcile_list
+  changed_when: false
+
+# The enumerator drops held packages rather than aborting the whole reconcile
+# on them; say so out loud, because their versions are then outside the freeze.
+- name: Report packages the reconcile skipped because they are held
+  ansible.builtin.debug:
+    msg: "{{ version_lock_reconcile_list.stderr_lines }}"
+  when: version_lock_reconcile_list.stderr | length > 0
+
+- name: Reconcile diverging packages to the snapshot versions
+  become: true
+  ansible.builtin.apt:
+    name: "{{ version_lock_reconcile_list.stdout_lines }}"
+    state: present
+    allow_downgrade: true
+  when: version_lock_reconcile_list.stdout_lines | length > 0

--- a/ansible/roles/version_lock/tasks/verify.yaml
+++ b/ansible/roles/version_lock/tasks/verify.yaml
@@ -48,6 +48,93 @@
           Locked mode installed versions that differ from the lockfile. The pinned
           version was unreachable in the configured sources, so apt fell back to
           another candidate. Refresh the lockfile or ros_snapshot_date:
-          {{ version_lock_drift | default([]) | join('\n') }}
+          {{ version_lock_drift_lines }}
         success_msg: All {{ version_lock_expected | length }} pinned packages match the lockfile.
         quiet: true
+      vars:
+        # quiet: true suppresses per-item output, so this fail_msg is the only
+        # place the drift list is shown. As at the three sites below, a literal
+        # block scalar leaves join('\n') as backslash-n, so precompute the
+        # joined text in a double-quoted var to get real newlines.
+        version_lock_drift_lines: "{{ version_lock_drift | default([]) | join(\"\n\") }}"
+
+    # The asserts above cover only packages listed in the lockfile. The two
+    # tasks below cover the ROS closure as a whole: after every role ran, no
+    # installed package may diverge from what the dated snapshot serves
+    # (reconcile ran earlier; fresh installs always take the 1001-pinned
+    # snapshot candidate, so any hit here means the freeze is broken).
+    # See reconcile.yaml for why the interpreter is /usr/bin/python3 and not a
+    # bare `python3` or a templated ansible_python_interpreter.
+    - name: Re-check installed packages against the ROS snapshot
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/python3
+          - "{{ role_path }}/files/list_ros_snapshot_drift.py"
+      register: version_lock_closure_drift
+      changed_when: false
+
+    # Held packages are excluded from the closure assert below, so name them:
+    # a hold is the one supported way to keep a package outside the freeze.
+    - name: Report packages the closure check skipped because they are held
+      ansible.builtin.debug:
+        msg: "{{ version_lock_closure_drift.stderr_lines }}"
+      when: version_lock_closure_drift.stderr | length > 0
+
+    - name: Fail if any installed package diverged from the ROS snapshot
+      ansible.builtin.assert:
+        that: version_lock_closure_drift.stdout_lines | length == 0
+        fail_msg: |-
+          Installed packages diverge from the {{ locked_packages.ros_snapshot_date }} ROS snapshot:
+          {{ version_lock_closure_drift_lines }}
+        success_msg: ROS closure matches the {{ locked_packages.ros_snapshot_date }} snapshot.
+        quiet: true
+      vars:
+        # A folded/literal YAML block scalar leaves join('\n') as a literal
+        # backslash-n, not a real newline (only YAML's own double-quoted-scalar
+        # escape processing decodes \n before Jinja sees it). Precompute the
+        # joined text in a double-quoted var so fail_msg renders one item per line.
+        version_lock_closure_drift_lines: "{{ version_lock_closure_drift.stdout_lines | join(\"\n\") }}"
+
+    - name: List manually-installed packages after roles ran
+      ansible.builtin.command: apt-mark showmanual
+      register: version_lock_manual_after
+      changed_when: false
+      when: version_lock_manual_before is defined
+
+    - name: Identify packages this run installed top-level from the Ubuntu archive
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/python3
+          - "{{ role_path }}/files/check_pin_completeness.py"
+      args:
+        # A folded YAML block scalar (>-) does not decode backslash escapes, so
+        # join('\n') would reach the script as a literal backslash-n and never
+        # split into lines. A double-quoted scalar lets YAML's own \n escape
+        # produce a real newline before Jinja evaluates the expression.
+        stdin: "{{ version_lock_manual_after.stdout_lines
+          | difference(version_lock_manual_before.stdout_lines)
+          | join(\"\n\") }}"
+      register: version_lock_new_ubuntu_pkgs
+      changed_when: false
+      when: version_lock_manual_before is defined
+
+    - name: Fail if a newly-installed Ubuntu package has no apt_pins entry
+      ansible.builtin.assert:
+        that: version_lock_missing_pins | length == 0
+        fail_msg: |-
+          Locked mode installed top-level Ubuntu-archive packages that have no
+          apt_pins entry, so their versions are not frozen. Add them to every
+          ansible/vars/locked-versions-*.yaml (the regenerate workflow refreshes
+          values but never discovers new keys):
+          {{ version_lock_missing_pins_lines }}
+        success_msg: All newly-installed Ubuntu packages are covered by apt_pins.
+        quiet: true
+      vars:
+        version_lock_missing_pins: >-
+          {{ version_lock_new_ubuntu_pkgs.stdout_lines | default([])
+             | difference((locked_packages.apt_pins | default({})).keys() | list) }}
+        # See the note on the "diverged from the ROS snapshot" assert above:
+        # fail_msg is a literal block scalar, so join('\n') must be precomputed
+        # in a double-quoted var to get real newlines instead of "\n" text.
+        version_lock_missing_pins_lines: "{{ version_lock_missing_pins | join(\"\n\") }}"
+      when: version_lock_manual_before is defined

--- a/ansible/scripts/emit_nvidia_pins.py
+++ b/ansible/scripts/emit_nvidia_pins.py
@@ -139,7 +139,7 @@ def installed_nvidia_pins():
     return dict(sorted(pins.items()))
 
 
-def render(header, data):
+def render(header, data, closure_only=False):
     unknown = set(data) - KNOWN_KEYS
     if unknown:
         sys.exit(
@@ -147,8 +147,12 @@ def render(header, data):
             + ", ".join(sorted(unknown))
         )
     lines = [header.rstrip("\n")]
-    lines.append(f'ros_snapshot_date: "{data["ros_snapshot_date"]}"')
-    for key in ("apt_pins", "pip_pins", "nvidia_pins", "ros_overrides"):
+    if closure_only:
+        keys = ("nvidia_pins",)
+    else:
+        lines.append(f'ros_snapshot_date: "{data["ros_snapshot_date"]}"')
+        keys = ("apt_pins", "pip_pins", "nvidia_pins", "ros_overrides")
+    for key in keys:
         section = data.get(key) or {}
         if not section:
             lines.append(f"{key}: {{}}")
@@ -177,13 +181,18 @@ def main():
             header_lines.append(line)
         else:
             break
-    if "ros_snapshot_date" not in data:
+    # A consumer that overrides cuda_version/tensorrt_version keeps its closure in
+    # a file holding nvidia_pins alone, passed to version_lock as
+    # nvidia_lockfile_path. Such a file has no ROS sections to preserve, so
+    # ros_snapshot_date is not required of it — and must not be invented for it.
+    closure_only = set(data) <= {"nvidia_pins"}
+    if not closure_only and "ros_snapshot_date" not in data:
         sys.exit(f"Error: {path} has no ros_snapshot_date; is it a filled lockfile?")
     data["nvidia_pins"] = installed_nvidia_pins()
     # Render before truncating the output file: render() can sys.exit (e.g. on an
     # unknown top-level key), and opening in "w" mode truncates immediately, so
     # rendering first avoids destroying the lockfile on a failed run.
-    rendered = render("\n".join(header_lines), data)
+    rendered = render("\n".join(header_lines), data, closure_only=closure_only)
     with open(path, "w") as fh:
         fh.write(rendered)
     print(f"Updated nvidia_pins ({len(data['nvidia_pins'])} packages) in {path}")

--- a/ansible/scripts/generate_ansible_lockfile.sh
+++ b/ansible/scripts/generate_ansible_lockfile.sh
@@ -115,7 +115,7 @@ else:
 # Platform: ${ARCH}
 # Ubuntu: $(lsb_release -rs) ($(lsb_release -cs))
 #
-# ros_snapshot_date freezes the entire ROS closure via snapshots.ros.org.
+# ros_snapshot_date freezes every ROS package snapshots.ros.org serves on that date.
 ros_snapshot_date: "${ROS_SNAPSHOT_DATE}"
 apt_pins:
 HEADER

--- a/ansible/vars/locked-versions-humble-amd64.yaml
+++ b/ansible/vars/locked-versions-humble-amd64.yaml
@@ -3,15 +3,19 @@
 # Platform: amd64
 # Ubuntu: 22.04 (jammy)
 #
-# ros_snapshot_date freezes the entire ROS closure via snapshots.ros.org.
+# ros_snapshot_date freezes every ROS package snapshots.ros.org serves on that date.
 # apt_pins are finalized by ansible/scripts/generate_ansible_lockfile.sh.
 ros_snapshot_date: "2026-05-14"
 apt_pins:
+  build-essential: 12.9ubuntu3
   ccache: 4.5.1-1
+  cmake: 3.22.1-1ubuntu1.22.04.2
   geographiclib-tools: 1.52-1
+  git: 1:2.34.1-1ubuntu1.17
   git-lfs: 3.0.2-1ubuntu0.3
   golang: 2:1.18~0ubuntu2
   pipx: 1.0.0-1
+  python3-apt: 2.4.0ubuntu4.1
   python3-flake8-blind-except: 0.2.0-2
   python3-flake8-builtins: 1.5.3-3
   python3-flake8-class-newline: 1.6.0-2
@@ -24,7 +28,10 @@ apt_pins:
   python3-pytest-cov: 3.0.0-1
   python3-pytest-repeat: 0.9.1-2
   python3-pytest-rerunfailures: 10.2-1
-  wget: 1.21.2-2ubuntu1.1
+  python3-setuptools: 59.6.0-1.2ubuntu0.22.04.3
+  qt5ct: 1.5-1build1
+  rsync: 3.2.7-0ubuntu0.22.04.7
+  wget: 1.21.2-2ubuntu1.4
 pip_pins: {}
 nvidia_pins:
   cuda-cccl-12-8: 12.8.90-1

--- a/ansible/vars/locked-versions-humble-arm64.yaml
+++ b/ansible/vars/locked-versions-humble-arm64.yaml
@@ -3,14 +3,18 @@
 # Platform: arm64
 # Ubuntu: 22.04 (jammy)
 #
-# ros_snapshot_date freezes the entire ROS closure via snapshots.ros.org.
+# ros_snapshot_date freezes every ROS package snapshots.ros.org serves on that date.
 ros_snapshot_date: "2026-05-14"
 apt_pins:
+  build-essential: 12.9ubuntu3
   ccache: 4.5.1-1
+  cmake: 3.22.1-1ubuntu1.22.04.2
   geographiclib-tools: 1.52-1
+  git: 1:2.34.1-1ubuntu1.17
   git-lfs: 3.0.2-1ubuntu0.3
   golang: 2:1.18~0ubuntu2
   pipx: 1.0.0-1
+  python3-apt: 2.4.0ubuntu4.1
   python3-flake8-blind-except: 0.2.0-2
   python3-flake8-builtins: 1.5.3-3
   python3-flake8-class-newline: 1.6.0-2
@@ -23,7 +27,10 @@ apt_pins:
   python3-pytest-cov: 3.0.0-1
   python3-pytest-repeat: 0.9.1-2
   python3-pytest-rerunfailures: 10.2-1
-  wget: 1.21.2-2ubuntu1.1
+  python3-setuptools: 59.6.0-1.2ubuntu0.22.04.3
+  qt5ct: 1.5-1build1
+  rsync: 3.2.7-0ubuntu0.22.04.7
+  wget: 1.21.2-2ubuntu1.4
 pip_pins: {}
 nvidia_pins:
   cuda-cccl-12-8: 12.8.90-1

--- a/ansible/vars/locked-versions-jazzy-amd64.yaml
+++ b/ansible/vars/locked-versions-jazzy-amd64.yaml
@@ -3,15 +3,19 @@
 # Platform: amd64
 # Ubuntu: 24.04 (noble)
 #
-# ros_snapshot_date freezes the entire ROS closure via snapshots.ros.org.
+# ros_snapshot_date freezes every ROS package snapshots.ros.org serves on that date.
 # apt_pins are finalized by ansible/scripts/generate_ansible_lockfile.sh.
 ros_snapshot_date: "2026-04-13"
 apt_pins:
+  build-essential: 12.10ubuntu1
   ccache: 4.9.1-1
+  cmake: 3.28.3-1build7
   geographiclib-tools: 2.3-1build1
+  git: 1:2.43.0-1ubuntu7.3
   git-lfs: 3.4.1-1ubuntu0.4
   golang: 2:1.22~2build1
   pipx: 1.4.3-1
+  python3-apt: 2.7.7ubuntu5.2
   python3-flake8-blind-except: 0.2.1-1
   python3-flake8-builtins: 2.1.0-1
   python3-flake8-class-newline: 1.6.0-5
@@ -24,7 +28,10 @@ apt_pins:
   python3-pytest-cov: 4.1.0-1
   python3-pytest-repeat: 0.9.3-1
   python3-pytest-rerunfailures: 12.0-1
-  wget: 1.21.4-1ubuntu4.1
+  python3-setuptools: 68.1.2-2ubuntu1.2
+  qt5ct: 1.5-1build11
+  rsync: 3.2.7-1ubuntu1.5
+  wget: 1.21.4-1ubuntu4.4
 pip_pins: {}
 nvidia_pins:
   cuda-cccl-13-0: 13.0.85-1

--- a/ansible/vars/locked-versions-jazzy-arm64.yaml
+++ b/ansible/vars/locked-versions-jazzy-arm64.yaml
@@ -3,14 +3,18 @@
 # Platform: arm64
 # Ubuntu: 24.04 (noble)
 #
-# ros_snapshot_date freezes the entire ROS closure via snapshots.ros.org.
+# ros_snapshot_date freezes every ROS package snapshots.ros.org serves on that date.
 ros_snapshot_date: "2026-04-13"
 apt_pins:
+  build-essential: 12.10ubuntu1
   ccache: 4.9.1-1
+  cmake: 3.28.3-1build7
   geographiclib-tools: 2.3-1build1
+  git: 1:2.43.0-1ubuntu7.3
   git-lfs: 3.4.1-1ubuntu0.4
   golang: 2:1.22~2build1
   pipx: 1.4.3-1
+  python3-apt: 2.7.7ubuntu5.2
   python3-flake8-blind-except: 0.2.1-1
   python3-flake8-builtins: 2.1.0-1
   python3-flake8-class-newline: 1.6.0-5
@@ -23,7 +27,10 @@ apt_pins:
   python3-pytest-cov: 4.1.0-1
   python3-pytest-repeat: 0.9.3-1
   python3-pytest-rerunfailures: 12.0-1
-  wget: 1.21.4-1ubuntu4.1
+  python3-setuptools: 68.1.2-2ubuntu1.2
+  qt5ct: 1.5-1build11
+  rsync: 3.2.7-1ubuntu1.5
+  wget: 1.21.4-1ubuntu4.4
 pip_pins: {}
 nvidia_pins:
   cuda-cccl-13-0: 13.0.85-1

--- a/docker/README.md
+++ b/docker/README.md
@@ -116,12 +116,13 @@ USE_LOCKFILE=true ROS_DISTRO=humble docker buildx bake -f docker/docker-bake.hcl
 When enabled, the build:
 
 - pins the base image to the per-distro digest in `BASE_IMAGE_DIGESTS` (`docker/docker-bake.hcl`) instead of the floating `ros:<distro>-ros-base` tag, freezing the OS-level closure;
-- passes `use_locked_versions=true` to ansible, which pins Ubuntu-archive packages to the versions in `ansible/vars/locked-versions-<distro>-<arch>.yaml` and points ROS at the dated `snapshots.ros.org` source recorded in that lockfile, freezing the entire ROS dependency closure; and
+- passes `use_locked_versions=true` to ansible, which pins Ubuntu-archive packages to the versions in `ansible/vars/locked-versions-<distro>-<arch>.yaml` and points ROS at the dated `snapshots.ros.org` source recorded in that lockfile, freezing every ROS dependency that snapshot serves;
+- walks any package the base image preinstalled at a different version than the snapshot back to the snapshot's version (the floating `ros:<distro>-ros-base` tag is usually newer than the lockfile's `ros_snapshot_date`), so every snapshot-served package in the final image is at its snapshot version; and
 - verifies after install that every locked package landed at its pinned version, failing the build on any drift.
 
-Only distros that have **both** a lockfile and a `BASE_IMAGE_DIGESTS` entry can be built in locked mode (currently `humble` and `jazzy`); requesting `USE_LOCKFILE=true` for any other `ROS_DISTRO` fails the build rather than silently falling back to a floating base. The CUDA targets (`base-cuda-*`, `universe-cuda`) are intentionally not locked: they inherit the frozen apt pins and dated snapshot from the `base` image they build on, but the CUDA / cuDNN / TensorRT packages from NVIDIA's apt repositories are not yet covered by the lockfile.
+Only distros that have **both** a lockfile and a `BASE_IMAGE_DIGESTS` entry can be built in locked mode (currently `humble` and `jazzy`); requesting `USE_LOCKFILE=true` for any other `ROS_DISTRO` fails the build rather than silently falling back to a floating base. The CUDA targets (`base-cuda-*`, `universe-cuda`) also build in locked mode: they inherit the frozen apt pins and dated snapshot from the `base` image they build on, and the CUDA / cuDNN / TensorRT closure from NVIDIA's apt repositories is frozen by the lockfile's `nvidia_pins` section. NVIDIA publishes no dated snapshot, so that closure is pinned by exact version per package (see the version_lock README for how `nvidia_pins` is recorded).
 
-See [`ansible/roles/version_lock/README.md`](../ansible/roles/version_lock/README.md) for the lockfile format and how to generate or update lockfiles.
+Locked mode is not a hermetic build. The rolling `packages.ros.org` source stays configured, so a `ros-*` package the dated snapshot does not carry — Autoware's own released packages among them — still installs from rolling and floats. See "What the freeze does not cover" in [`ansible/roles/version_lock/README.md`](../ansible/roles/version_lock/README.md), which also documents the lockfile format and how to generate or update lockfiles.
 
 ## Usage
 

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -23,7 +23,7 @@ repositories:
   core/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git
-    version: 1.2.0
+    version: 1.4.0
   core/autoware_utils:
     type: git
     url: https://github.com/autowarefoundation/autoware_utils.git

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -19,7 +19,7 @@ repositories:
   core/autoware_internal_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_internal_msgs.git
-    version: 1.14.0
+    version: 1.15.0
   core/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -97,10 +97,6 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/bevdet_vendor.git
     version: 0.1.0
-  universe/external/trt_batched_nms:
-    type: git
-    url: https://github.com/autowarefoundation/trt_batched_nms.git
-    version: 0.1.0
   universe/external/cuda_blackboard:
     type: git
     url: https://github.com/autowarefoundation/cuda_blackboard.git


### PR DESCRIPTION
## Description

Builds on #225 (`fix(ansible): make locked mode deliver a fully frozen closure`). That PR fixes locked mode's dependency-closure logic; this PR adds the CI lanes that actually exercise the locked install path. Before this change no workflow ever ran with `use_locked_versions=true` / `USE_LOCKFILE=true`, so a locked-mode regression (or an unresolvable package like `ros-build-essential`) was invisible to CI — every locked-mode fix in #225 had only been verified by a local, manual harness.

This branch is cut from #225's head, so its diff against `main` also contains #225's commits. That is expected for fork staging: the fork doesn't have a merged version of #225 to rebase onto yet. The real upstream `ci/locked-install-path` PR will be rebased onto upstream `main` after the upstream counterpart of #225 merges, at which point its diff will shrink to just the one CI commit below.

### What changed

- `health-check-ansible.yaml`: added a `locked: [false, true]` matrix axis to `install-dev-env`, so the job now runs 4 cells (`ubuntu:22.04` and `ubuntu:24.04` × unlocked/locked). The playbook invocation passes it through as `-e use_locked_versions=${{ matrix.locked }}`. The disk-usage step-summary heading now includes the locked state so the two cells per image are distinguishable in the summary. `install-dev-env-required` needs no change — it keys off the whole matrix result (`needs.install-dev-env.result`), not individual cell names.
- `validate-lockfiles.yaml`: added a `build-locked-base` job that builds the locked `base` image for both `humble` and `jazzy` with `USE_LOCKFILE=true`, gated behind the same `run:health-check` label the repo already uses for its other expensive lanes. The workflow's trigger paths were widened from lockfile-and-bake-file-only to everything that can change the outcome of a locked build — `ansible/roles/**`, `ansible/vars/**`, `ansible/playbooks/**`, `ansible/scripts/**`, `docker/*.Dockerfile`, `docker/docker-bake.hcl` — so role, playbook, script and Dockerfile changes exercise the locked build too, not just direct lockfile edits. The list is deliberately narrower than `ansible/**` and `docker/**`, which would drag in READMEs and `docker/examples` and make a docs-only PR trigger two cold container builds.

### Notes for reviewers

- Adding the `locked` axis changes the `install-dev-env` matrix check names — e.g. `install-dev-env (ubuntu:22.04)` becomes two checks, `install-dev-env (ubuntu:22.04, false)` and `install-dev-env (ubuntu:22.04, true)`. `install-dev-env-required` is the intended stable branch-protection anchor and its behavior is unchanged by this PR, but whoever merges this should confirm branch protection actually points at that aggregator rather than at raw matrix-cell names, since those names just changed.
- `build-locked-base` has no required-check aggregator of its own yet (unlike `install-dev-env-required` for the other job). Both `humble` and `jazzy` cells need to be watched individually until one is added. It only runs when the PR carries `run:health-check`; without the label the `require-label` job resolves to `false` and the bake is skipped, so the cheap `validate-lockfiles` job stays the default cost of touching a lockfile.
- Copilot review is not enabled on this fork, so it was not requested here.

## How was this PR tested?

Opened as a draft PR on the fork and polled `install-dev-env` (all 4 cells) and `build-locked-base` (both distros) to a terminal state. Results and runner labels observed are recorded in the PR thread / CI checks below.

