### PR TITLE
fix(ansible): key the locked NVIDIA closure by CUDA generation

### DIFF
--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -26,6 +26,26 @@
   register: cuda__dash_case_cuda_version
   changed_when: false
 
+# The CUDA packages carry version-suffixed names, so a closure from another
+# generation does not collide with them — it simply fails to cover them, and the
+# install proceeds against whatever the accretive NVIDIA repo serves that day.
+# verify.yaml cannot catch that either: it reports drift only for lockfile keys
+# that are installed, and the other generation's keys never are.
+- name: Assert the locked NVIDIA closure covers this cuda_version
+  ansible.builtin.assert:
+    that:
+      - ("cuda-minimal-build-" ~ cuda__dash_case_cuda_version.stdout) in locked_packages.nvidia_pins
+    fail_msg: >-
+      Locked mode: nvidia_pins has no
+      cuda-*-{{ cuda__dash_case_cuda_version.stdout }} entries, so the CUDA
+      closure this run installs would not be frozen. Point nvidia_lockfile_path
+      at a closure recorded for cuda_version={{ cuda_version }}, or drop the
+      cuda_version override.
+    quiet: true
+  when:
+    - use_locked_versions | default(false) | bool
+    - (locked_packages.nvidia_pins | default({})) | length > 0
+
 - name: Install CUDA devel libraries except for cuda-drivers
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -1,3 +1,23 @@
+# The TensorRT packages carry unversioned names, so a lockfile whose closure is
+# from another CUDA generation pins the very names installed below. Its pin and
+# the 1001 Ansible's apt module gives its own pkg=version request tie, apt keeps
+# the higher version, and the install fails with a bare "no available
+# installation candidate" that names neither the pin nor the lockfile.
+- name: Assert the locked NVIDIA closure matches tensorrt_version
+  ansible.builtin.assert:
+    that:
+      - locked_packages.nvidia_pins.libnvinfer10 == tensorrt_version
+    fail_msg: >-
+      Locked mode: the lockfile pins libnvinfer10 to
+      {{ locked_packages.nvidia_pins.libnvinfer10 }}, but this run requests
+      tensorrt_version={{ tensorrt_version }}. Point nvidia_lockfile_path at a
+      closure recorded for this TensorRT version, or drop the tensorrt_version
+      override.
+    quiet: true
+  when:
+    - use_locked_versions | default(false) | bool
+    - (locked_packages.nvidia_pins | default({})).libnvinfer10 is defined
+
 - name: Install TensorRT
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -77,7 +77,7 @@ tell an NVIDIA-repo package from an Ubuntu-archive one. On a machine that has ju
 completed an **unlocked** `install_nvidia`, run:
 
 ```bash
-sudo apt-get update
+sudo apt-get update && sudo apt-get install -y python3-apt python3-yaml   # the script imports both
 ./ansible/scripts/emit_nvidia_pins.py ansible/vars/locked-versions-<rosdistro>-<arch>.yaml
 ```
 

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -32,7 +32,7 @@ ansible-playbook autoware.dev_env.install_nvidia \
   --extra-vars "nvidia_lockfile_path=/path/to/locked-nvidia-ubuntu2404-cuda12.8-amd64.yaml"
 ```
 
-The file needs only a top-level `nvidia_pins` mapping, in the same format as a lockfile's. It **replaces** `nvidia_pins` rather than merging into it, and `verify.yaml` then checks the substituted closure, so the pins stay exact and the freeze is unchanged — only the source file moves.
+The file needs only a top-level `nvidia_pins` mapping, in the same format as a lockfile's, and is produced the same way (`emit_nvidia_pins.py`, see below). It **replaces** `nvidia_pins` rather than merging into it, and `verify.yaml` then checks the substituted closure, so the pins stay exact and the freeze is unchanged — only the source file moves.
 
 Leaving `nvidia_lockfile_path` empty while overriding a version is not silently tolerated: the `cuda` role fails when no `cuda-*-<version>` entry covers this run, and the `tensorrt` role fails when the pinned `libnvinfer10` disagrees with `tensorrt_version`. Without those guards the CUDA half would install unfrozen (its version-suffixed names simply are not in the closure, and `verify.yaml` reports drift only for keys that are installed) and the TensorRT half would fail with an unattributable `no available installation candidate`.
 
@@ -93,6 +93,17 @@ The two generators are order-independent on an already-filled lockfile — `gene
 preserves `nvidia_pins` and this script preserves `apt_pins`/`pip_pins` — but both must run on a
 machine provisioned from the same snapshot date. On a lockfile that has no `ros_snapshot_date` yet,
 run `generate_ansible_lockfile.sh` first; this script refuses an unfilled lockfile.
+
+The same script records a **closure-only** file for `nvidia_lockfile_path`. Given a file whose only
+top-level key is `nvidia_pins` (an empty one, or one carrying just a header comment), it fills that
+key and leaves the file with no ROS sections — so a consumer's closure never carries a
+`ros_snapshot_date` it does not own. Run it on a machine provisioned with the `cuda_version` /
+`tensorrt_version` that file is meant to describe:
+
+```bash
+printf '# NVIDIA closure for ubuntu2404 / CUDA 12.8 / amd64\nnvidia_pins: {}\n' >closure.yaml
+./ansible/scripts/emit_nvidia_pins.py closure.yaml
+```
 
 ## When you add a new dependency
 

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -22,6 +22,20 @@ To use a custom lockfile, override `lockfile_path`:
 ansible-playbook autoware.dev_env.install_dev_env --extra-vars "use_locked_versions=true lockfile_path=/path/to/my-lockfile.yaml" --ask-become-pass
 ```
 
+#### Overriding only the NVIDIA closure
+
+`(rosdistro, arch)` does not identify the CUDA/TensorRT closure. That closure is a function of `(cuda_repo_distro, cuda_version, tensorrt_version, arch)`, and the `cuda` and `tensorrt` roles let a consumer override all four — so `locked-versions-<rosdistro>-<arch>.yaml` can only carry the generation those roles default to for that distro (CUDA 13.0 on 24.04, 12.8 on 22.04). A consumer that overrides `cuda_version` or `tensorrt_version` must supply the matching closure through `nvidia_lockfile_path`:
+
+```bash
+ansible-playbook autoware.dev_env.install_nvidia \
+  --extra-vars "use_locked_versions=true cuda_version=12.8 tensorrt_version=10.8.0.43-1+cuda12.8" \
+  --extra-vars "nvidia_lockfile_path=/path/to/locked-nvidia-ubuntu2404-cuda12.8-amd64.yaml"
+```
+
+The file needs only a top-level `nvidia_pins` mapping, in the same format as a lockfile's. It **replaces** `nvidia_pins` rather than merging into it, and `verify.yaml` then checks the substituted closure, so the pins stay exact and the freeze is unchanged — only the source file moves.
+
+Leaving `nvidia_lockfile_path` empty while overriding a version is not silently tolerated: the `cuda` role fails when no `cuda-*-<version>` entry covers this run, and the `tensorrt` role fails when the pinned `libnvinfer10` disagrees with `tensorrt_version`. Without those guards the CUDA half would install unfrozen (its version-suffixed names simply are not in the closure, and `verify.yaml` reports drift only for keys that are installed) and the TensorRT half would fail with an unattributable `no available installation candidate`.
+
 ### Snapshot reconcile
 
 In locked mode the role does not only pin future installs: right after the

--- a/ansible/roles/version_lock/defaults/main.yaml
+++ b/ansible/roles/version_lock/defaults/main.yaml
@@ -3,3 +3,11 @@ version_lock_arch_map:
   aarch64: arm64
 # lockfile_path is the published interface-contract variable; renaming would break consumers.
 lockfile_path: "{{ role_path }}/../../vars/locked-versions-{{ rosdistro }}-{{ version_lock_arch_map[ansible_architecture] | default(ansible_architecture) }}.yaml" # noqa: var-naming[no-role-prefix]
+# Optional path to a file whose nvidia_pins describe the CUDA/TensorRT closure
+# THIS run installs. That closure is a function of (cuda_repo_distro,
+# cuda_version, tensorrt_version, arch) and not of rosdistro, so
+# locked-versions-<rosdistro>-<arch>.yaml can only carry the generation the
+# cuda/tensorrt role defaults pick for that distro. A consumer overriding
+# cuda_version or tensorrt_version must point this at its own closure file.
+# Empty means: use the nvidia_pins in lockfile_path.
+nvidia_lockfile_path: "" # noqa: var-naming[no-role-prefix]

--- a/ansible/roles/version_lock/tasks/main.yaml
+++ b/ansible/roles/version_lock/tasks/main.yaml
@@ -14,6 +14,37 @@
       The lockfile may be an unfilled arm64 template.
   when: use_locked_versions | default(false) | bool
 
+- name: Load the consumer-supplied NVIDIA closure
+  ansible.builtin.include_vars:
+    file: "{{ nvidia_lockfile_path }}"
+    name: version_lock_nvidia
+  when:
+    - use_locked_versions | default(false) | bool
+    - nvidia_lockfile_path | length > 0
+
+- name: Assert the consumer-supplied NVIDIA closure provides nvidia_pins
+  ansible.builtin.assert:
+    that:
+      - version_lock_nvidia.nvidia_pins is defined
+      - version_lock_nvidia.nvidia_pins | length > 0
+    fail_msg: >-
+      nvidia_lockfile_path={{ nvidia_lockfile_path }} must define a non-empty
+      'nvidia_pins' mapping.
+  when:
+    - use_locked_versions | default(false) | bool
+    - nvidia_lockfile_path | length > 0
+
+# Substituted, not merged: a consumer supplies its own closure precisely because
+# it installs a different CUDA generation, so keeping the lockfile's own entries
+# would pin packages this run never installs — and, for the unversioned TensorRT
+# names, would pin them to the wrong generation.
+- name: Substitute the consumer-supplied NVIDIA closure # noqa: var-naming[no-role-prefix]
+  ansible.builtin.set_fact:
+    locked_packages: "{{ locked_packages | combine({'nvidia_pins': version_lock_nvidia.nvidia_pins}) }}"
+  when:
+    - use_locked_versions | default(false) | bool
+    - nvidia_lockfile_path | length > 0
+
 - name: Create APT version pins
   become: true
   ansible.builtin.template:

--- a/ansible/scripts/emit_nvidia_pins.py
+++ b/ansible/scripts/emit_nvidia_pins.py
@@ -139,7 +139,7 @@ def installed_nvidia_pins():
     return dict(sorted(pins.items()))
 
 
-def render(header, data):
+def render(header, data, closure_only=False):
     unknown = set(data) - KNOWN_KEYS
     if unknown:
         sys.exit(
@@ -147,8 +147,12 @@ def render(header, data):
             + ", ".join(sorted(unknown))
         )
     lines = [header.rstrip("\n")]
-    lines.append(f'ros_snapshot_date: "{data["ros_snapshot_date"]}"')
-    for key in ("apt_pins", "pip_pins", "nvidia_pins", "ros_overrides"):
+    if closure_only:
+        keys = ("nvidia_pins",)
+    else:
+        lines.append(f'ros_snapshot_date: "{data["ros_snapshot_date"]}"')
+        keys = ("apt_pins", "pip_pins", "nvidia_pins", "ros_overrides")
+    for key in keys:
         section = data.get(key) or {}
         if not section:
             lines.append(f"{key}: {{}}")
@@ -177,13 +181,18 @@ def main():
             header_lines.append(line)
         else:
             break
-    if "ros_snapshot_date" not in data:
+    # A consumer that overrides cuda_version/tensorrt_version keeps its closure in
+    # a file holding nvidia_pins alone, passed to version_lock as
+    # nvidia_lockfile_path. Such a file has no ROS sections to preserve, so
+    # ros_snapshot_date is not required of it — and must not be invented for it.
+    closure_only = set(data) <= {"nvidia_pins"}
+    if not closure_only and "ros_snapshot_date" not in data:
         sys.exit(f"Error: {path} has no ros_snapshot_date; is it a filled lockfile?")
     data["nvidia_pins"] = installed_nvidia_pins()
     # Render before truncating the output file: render() can sys.exit (e.g. on an
     # unknown top-level key), and opening in "w" mode truncates immediately, so
     # rendering first avoids destroying the lockfile on a failed run.
-    rendered = render("\n".join(header_lines), data)
+    rendered = render("\n".join(header_lines), data, closure_only=closure_only)
     with open(path, "w") as fh:
         fh.write(rendered)
     print(f"Updated nvidia_pins ({len(data['nvidia_pins'])} packages) in {path}")


### PR DESCRIPTION
Fork staging PR for review + CI, based on `fix/version-lock-frozen-closure` (upstream #7237) so the diff is exactly this fix. Intended to be folded into that PR.

## The gap

`lockfile_path` is keyed by `(rosdistro, arch)`, but the CUDA/TensorRT closure the lockfile carries is a function of `(cuda_repo_distro, cuda_version, tensorrt_version, arch)`. Both version variables are documented, overridable role defaults — `roles/cuda/defaults/main.yaml` explicitly documents "installing CUDA 12.x on a 24.04 host" — so `locked-versions-<rosdistro>-<arch>.yaml` can only ever describe the generation the role defaults pick for that distro, and a consumer that overrides either version has no way to be covered by the freeze.

Concretely: `locked-versions-jazzy-amd64.yaml` pins `libnvinfer10: 10.13.3.9-1+cuda13.0` and 23 `cuda-*-13-0` names, because #7108 flipped 24.04 to CUDA 13 for Thor and #7205 recorded the closure faithfully. A jazzy consumer on `cuda_version=12.8` (Pilot.Auto X2, `tensorrt_version=10.8.0.43-1+cuda12.8`) then fails two different ways, neither naming the cause:

- **TensorRT — hard failure.** Those packages carry *unversioned* names, so the lockfile pins the very names the run installs, at `Pin-Priority: 1001`. Ansible's apt module gives its own `pkg=version` request the same 1001 (`package_best_match` → `policy.create_pin(..., 1001)`). On a tie apt keeps the higher version, `fnmatch` fails, `package_best_match` returns `None`, and `ansible.builtin.apt` reports `no available installation candidate for libnvinfer10=10.8.0.43-1+cuda12.8`.
- **CUDA — silent non-freeze.** Those packages carry *version-suffixed* names, so they do not collide; they are simply absent from the closure and resolve to whatever the accretive NVIDIA repo serves that day. `verify.yaml` cannot catch it: it reports drift only for lockfile keys that are *installed*, and the other generation's keys never are — so it asserts "all pinned packages match the lockfile" over a closure that froze nothing this run installed. `check_pin_completeness.py` excludes NVIDIA-repo packages by design, so nothing covers this.

The template author already knew about the priority tie and documented it for ROS overrides (`autoware-lock.pref.j2`: priority 1002 "so an override beats the snapshot-origin pin above (at equal priority apt would keep the snapshot's own, higher-numbered build)"). The same reasoning was never applied to `nvidia_pins`.

## The change

1. **`nvidia_lockfile_path`** (`version_lock`) — a file whose `nvidia_pins` **replace** the lockfile's. Substituted rather than merged, because a consumer supplies its own closure precisely when it installs a different generation, and keeping the lockfile's entries would pin the unversioned TensorRT names to the wrong one. `verify.yaml` builds `version_lock_expected` from `locked_packages`, so the substituted closure is checked by the existing drift assert. **No priority is lowered and no pin is dropped — the pins stay exact and at 1001. Only the source file moves.**
2. **Two guards** (`cuda`, `tensorrt`) — asserted next to the roles that own the variables: that a `cuda-*-<this version>` entry exists, and that the pinned `libnvinfer10` equals `tensorrt_version`. Both scoped to locked mode with a closure present, so unlocked runs and runs with no `nvidia_pins` are untouched. A run that overrides a version without supplying a closure now stops in seconds with an actionable message.
3. **`emit_nvidia_pins.py` closure-only mode** — a file whose only top-level key is `nvidia_pins` gets that key filled and no ROS sections emitted, so a consumer's closure never carries a `ros_snapshot_date` it does not own. Without this, the documented way to record one would be to generate a full lockfile and hand-copy a section out.

4. **Prerequisites named in the README** — `emit_nvidia_pins.py` imports both `apt` and `yaml`, but neither `python3-apt` nor `python3-yaml` is in `apt_pins`, and an unlocked `install_dev_env` installs neither (`version_lock` installs `python3-apt` only in locked mode). Following the documented recipe on a fresh 24.04 therefore dies with `ModuleNotFoundError: No module named 'yaml'` *after* the whole NVIDIA install has already run — hit while recording the closure for leg 2b below.

Deliberately **not** done: lowering `nvidia_pins` to `Pin-Priority: 1000`. It would unblock the consumer, but it converts the guarantee into a preference — any explicit `pkg=version` would then silently override the lockfile, which is the case the lock exists to catch — and it only moves the failure to `verify.yaml`'s drift assert.

## Verification

**Priority arithmetic** — Ansible's `package_best_match` run verbatim (`apt_pkg` 2.8.3 / `python3-apt` 2.7.7ubuntu5.2) against the live `ubuntu2404/x86_64` NVIDIA index (22 `libnvinfer10` versions), request `libnvinfer10 = 10.8.0.43-1+cuda12.8`, single-variable discrimination on the pin file alone:

| `/etc/apt/preferences.d/autoware-lock` | result |
| --- | --- |
| absent | `10.8.0.43-1+cuda12.8` |
| `jazzy-amd64` 13.0 closure @1001 | `None` — reproduces the reported failure |
| 12.8 closure @1001 | `10.8.0.43-1+cuda12.8` |

The fix works at the **unchanged** priority.

**No regression to the four shipped lockfiles** — for every `(distro, arch)` pair, the `cuda`/`tensorrt` role defaults still satisfy both new asserts:

| lockfile | default `cuda_version` | sentinel key | cuda assert | trt assert |
| --- | --- | --- | --- | --- |
| jazzy-amd64 | 13.0 | `cuda-minimal-build-13-0` | pass | pass |
| jazzy-arm64 | 13.0 | `cuda-minimal-build-13-0` | pass | pass |
| humble-amd64 | 12.8 | `cuda-minimal-build-12-8` | pass | pass |
| humble-arm64 | 12.8 | `cuda-minimal-build-12-8` | pass | pass |

**Closure availability** — all 46 entries of the existing `locked-versions-humble-amd64.yaml` 12.8 closure are served by the live `ubuntu2404/x86_64` index at those exact versions, so a jazzy+12.8 closure is producible today.

**Generator** — both render paths exercised directly; the full-lockfile path is byte-identical to before, and closure-only detection is asserted over `{}`, `{nvidia_pins}`, `{nvidia_pins, ros_snapshot_date}` and the full five-key set.

**Lint** — `pre-commit run` (yamllint, prettier, markdownlint, black, isort) clean; `ansible-lint` clean at the `production` profile.

**Ansible-level, on throwaway `ubuntu:24.04` containers** — `install_nvidia`, `prompt_install_nvidia=y`, `cuda_install_drivers=false`:

| leg | configuration | result |
| --- | --- | --- |
| 1 | locked, `cuda_version=12.8`, **no** `nvidia_lockfile_path` | `ok=10 failed=1` — stops at the **cuda** guard with the actionable message, before any CUDA download. Previously this configuration failed ~110 s in at `Install TensorRT` with `no available installation candidate` |
| 2 | unlocked, 12.8 | `ok=20 failed=0` — both guards correctly skipped |
| 2b | unlocked, 12.8, `install_devel=y`, then `emit_nvidia_pins.py` on a closure-only file | `ok=22 failed=0`; closure recorded, 46 entries |
| 3 | locked, 12.8, **with** that closure | `ok=38 changed=16 failed=0`. Both guards `ok`; `Substitute the consumer-supplied NVIDIA closure` ran; `Fail if any installed package drifted from the lockfile` → `ok`, i.e. the existing drift assert verified the **substituted** closure |
| 4 | locked, **role defaults** (CUDA 13.0), no overrides | `ok=33 failed=0`, both guards ran and passed — the regression case |

Leg 3 installed exactly the closure's versions:

```
libnvinfer10               10.8.0.43-1+cuda12.8
libnvinfer-plugin10        10.8.0.43-1+cuda12.8
libnvonnxparsers10         10.8.0.43-1+cuda12.8
libnvinfer-dev             10.8.0.43-1+cuda12.8
libnvinfer-headers-dev     10.8.0.43-1+cuda12.8
libnvonnxparsers-dev       10.8.0.43-1+cuda12.8
cuda-minimal-build-12-8    12.8.2-1
cuda-toolkit-config-common 13.3.29-1
```

**Independent corroboration of the recorded closure.** Leg 2b recorded its 46 entries on 24.04 against the `ubuntu2404` repo. They agree with the 12.8 closure `locked-versions-humble-amd64.yaml` already carries — captured on 22.04 against `ubuntu2204` — key for key and version for version, 46/46, zero disagreements. Two independent provenances for the same closure.

**Scope note on CI.** `health-check-ansible` runs `install_dev_env` with no NVIDIA. The docker `health-check` *does* install NVIDIA (`base-cuda.Dockerfile`, `universe-cuda`, `core` all run `install_nvidia`), but with `-e use_locked_versions=${USE_LOCKFILE}`, and `USE_LOCKFILE` defaults to `false` in `docker-bake.hcl` with no workflow overriding it. So **no CI lane installs NVIDIA in locked mode**, and the guards — being `when: use_locked_versions` — are not exercised by CI anywhere. The docker health-check is still a genuine regression check that the unlocked NVIDIA path is unchanged (the guards skip cleanly); the positive evidence for the guards is the container matrix above.
