### PR TITLE
fix(ansible): apply the #7237 code-review fixes (verification only)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -6,6 +6,7 @@
     "lockfiles",
     "metapackage",
     "runpip",
+    "selstate",
     "showmanual"
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,7 @@
   ],
   "words": [
     "lockfiles",
-    "runpip"
+    "runpip",
+    "showmanual"
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,7 @@
   ],
   "words": [
     "lockfiles",
+    "metapackage",
     "runpip",
     "showmanual"
   ]

--- a/.github/workflows/health-check-ansible.yaml
+++ b/.github/workflows/health-check-ansible.yaml
@@ -50,6 +50,9 @@ jobs:
         image:
           - ubuntu:22.04
           - ubuntu:24.04
+        locked:
+          - false
+          - true
     container:
       image: ${{ matrix.image }}
     steps:
@@ -80,7 +83,7 @@ jobs:
           bash ansible/scripts/install-ansible.sh
           export PATH="$HOME/.local/bin:$PATH"
           ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
-          ansible-playbook autoware.dev_env.install_dev_env --skip-tags artifacts -v
+          ansible-playbook autoware.dev_env.install_dev_env --skip-tags artifacts -e use_locked_versions=${{ matrix.locked }} -v
 
       - name: 📊 Report installation disk footprint
         run: |
@@ -90,7 +93,7 @@ jobs:
           delta_gb=$(awk -v b="${delta}" 'BEGIN { printf "%.2f", b/1e9 }')
           echo "📦 Installation disk usage: ${delta_gb} GB"
           {
-            echo "## 📦 Installation disk usage (\`${{ matrix.image }}\`)"
+            echo "## 📦 Installation disk usage (\`${{ matrix.image }}\`, locked=${{ matrix.locked }})"
             echo ""
             echo "Root filesystem grew by **${delta_gb} GB** during the install."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate-lockfiles.yaml
+++ b/.github/workflows/validate-lockfiles.yaml
@@ -2,10 +2,20 @@ name: validate-lockfiles
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+    # Only what can change the outcome of a locked build. Deliberately narrower
+    # than ansible/** and docker/**: both READMEs and docker/examples live under
+    # those, and a docs-only PR must not trigger two cold container builds.
     paths:
-      - ansible/**
-      - ansible/vars/locked-versions-*.yaml
-      - docker/**
+      - ansible/roles/**
+      - ansible/vars/**
+      - ansible/playbooks/**
+      - docker/*.Dockerfile
+      - docker/docker-bake.hcl
       - .github/workflows/validate-lockfiles.yaml
 
 concurrency:
@@ -30,7 +40,17 @@ jobs:
       - name: Validate lockfiles (format + digest/lockfile coverage)
         run: ./ansible/scripts/validate_lockfiles.sh
 
+  # The locked base bakes below are two cold, uncached container builds. Put
+  # them behind the same opt-in label the repo already uses for its other
+  # expensive lanes (see health-check-ansible.yaml).
+  require-label:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
+    with:
+      label: run:health-check
+
   build-locked-base:
+    needs: require-label
+    if: needs.require-label.outputs.result == 'true'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/validate-lockfiles.yaml
+++ b/.github/workflows/validate-lockfiles.yaml
@@ -3,8 +3,9 @@ name: validate-lockfiles
 on:
   pull_request:
     paths:
+      - ansible/**
       - ansible/vars/locked-versions-*.yaml
-      - docker/docker-bake.hcl
+      - docker/**
       - .github/workflows/validate-lockfiles.yaml
 
 concurrency:
@@ -28,3 +29,19 @@ jobs:
 
       - name: Validate lockfiles (format + digest/lockfile coverage)
         run: ./ansible/scripts/validate_lockfiles.sh
+
+  build-locked-base:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        rosdistro: [humble, jazzy]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the locked base image
+        run: USE_LOCKFILE=true ROS_DISTRO=${{ matrix.rosdistro }} docker buildx bake -f docker/docker-bake.hcl base

--- a/.github/workflows/validate-lockfiles.yaml
+++ b/.github/workflows/validate-lockfiles.yaml
@@ -7,13 +7,15 @@ on:
       - synchronize
       - reopened
       - labeled
-    # Only what can change the outcome of a locked build. Deliberately narrower
-    # than ansible/** and docker/**: both READMEs and docker/examples live under
+    # Only what can change the outcome of a locked build, plus the scripts that
+    # generate and validate the lockfiles themselves. Deliberately narrower than
+    # ansible/** and docker/**: both READMEs and docker/examples live under
     # those, and a docs-only PR must not trigger two cold container builds.
     paths:
       - ansible/roles/**
       - ansible/vars/**
       - ansible/playbooks/**
+      - ansible/scripts/**
       - docker/*.Dockerfile
       - docker/docker-bake.hcl
       - .github/workflows/validate-lockfiles.yaml

--- a/ansible/playbooks/install_image_deps.yaml
+++ b/ansible/playbooks/install_image_deps.yaml
@@ -24,6 +24,13 @@
       when: use_locked_versions | default(false) | bool
       tags: [always]
 
+    - name: Reconcile installed packages to the ROS snapshot (locked mode)
+      ansible.builtin.import_role:
+        name: autoware.dev_env.version_lock
+        tasks_from: reconcile
+      when: use_locked_versions | default(false) | bool
+      tags: [always]
+
   roles:
     - role: autoware.dev_env.rmw_implementation
       tags: [base, core, universe, rmw]

--- a/ansible/playbooks/install_rmw.yaml
+++ b/ansible/playbooks/install_rmw.yaml
@@ -27,3 +27,11 @@
       tags: [always]
   roles:
     - role: autoware.dev_env.rmw_implementation
+
+  post_tasks:
+    - name: Verify installed versions match the lockfile (locked mode)
+      ansible.builtin.import_role:
+        name: autoware.dev_env.version_lock
+        tasks_from: verify
+      when: use_locked_versions | default(false) | bool
+      tags: [always]

--- a/ansible/playbooks/install_rmw.yaml
+++ b/ansible/playbooks/install_rmw.yaml
@@ -18,5 +18,12 @@
         tasks_from: snapshot_source
       when: use_locked_versions | default(false) | bool
       tags: [always]
+
+    - name: Reconcile installed packages to the ROS snapshot (locked mode)
+      ansible.builtin.import_role:
+        name: autoware.dev_env.version_lock
+        tasks_from: reconcile
+      when: use_locked_versions | default(false) | bool
+      tags: [always]
   roles:
     - role: autoware.dev_env.rmw_implementation

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -26,6 +26,26 @@
   register: cuda__dash_case_cuda_version
   changed_when: false
 
+# The CUDA packages carry version-suffixed names, so a closure from another
+# generation does not collide with them — it simply fails to cover them, and the
+# install proceeds against whatever the accretive NVIDIA repo serves that day.
+# verify.yaml cannot catch that either: it reports drift only for lockfile keys
+# that are installed, and the other generation's keys never are.
+- name: Assert the locked NVIDIA closure covers this cuda_version
+  ansible.builtin.assert:
+    that:
+      - ("cuda-minimal-build-" ~ cuda__dash_case_cuda_version.stdout) in locked_packages.nvidia_pins
+    fail_msg: >-
+      Locked mode: nvidia_pins has no
+      cuda-*-{{ cuda__dash_case_cuda_version.stdout }} entries, so the CUDA
+      closure this run installs would not be frozen. Point nvidia_lockfile_path
+      at a closure recorded for cuda_version={{ cuda_version }}, or drop the
+      cuda_version override.
+    quiet: true
+  when:
+    - use_locked_versions | default(false) | bool
+    - (locked_packages.nvidia_pins | default({})) | length > 0
+
 - name: Install CUDA devel libraries except for cuda-drivers
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -34,7 +34,7 @@
 - name: Assert the locked NVIDIA closure covers this cuda_version
   ansible.builtin.assert:
     that:
-      - ("cuda-minimal-build-" ~ cuda__dash_case_cuda_version.stdout) in locked_packages.nvidia_pins
+      - ("cuda-minimal-build-" ~ cuda__dash_case_cuda_version.stdout) in (locked_packages.nvidia_pins | default({}))
     fail_msg: >-
       Locked mode: nvidia_pins has no
       cuda-*-{{ cuda__dash_case_cuda_version.stdout }} entries, so the CUDA
@@ -42,9 +42,11 @@
       at a closure recorded for cuda_version={{ cuda_version }}, or drop the
       cuda_version override.
     quiet: true
-  when:
-    - use_locked_versions | default(false) | bool
-    - (locked_packages.nvidia_pins | default({})) | length > 0
+  # Deliberately not also gated on nvidia_pins being non-empty: an empty
+  # closure covers nothing, which is exactly when this assert is needed.
+  # locked_packages is always loaded first — every playbook that reaches this
+  # role imports version_lock as a pre_task tagged 'always'.
+  when: use_locked_versions | default(false) | bool
 
 - name: Install CUDA devel libraries except for cuda-drivers
   become: true

--- a/ansible/roles/qt5ct_setup/tasks/main.yml
+++ b/ansible/roles/qt5ct_setup/tasks/main.yml
@@ -1,3 +1,4 @@
+# cspell:ignore Xsession
 # state: latest so an already-installed package is converged onto the pinned
 # version in locked mode; state: present would leave whatever the machine came
 # with, and the lockfile verification would then fail on a package no task

--- a/ansible/roles/qt5ct_setup/tasks/main.yml
+++ b/ansible/roles/qt5ct_setup/tasks/main.yml
@@ -2,12 +2,16 @@
 # state: latest so an already-installed package is converged onto the pinned
 # version in locked mode; state: present would leave whatever the machine came
 # with, and the lockfile verification would then fail on a package no task
-# would ever move.
+# would ever move. state: latest resolves against the apt index, so refresh it
+# first: without update_cache a standalone `--tags qt5ct_setup` run would be an
+# unconditional upgrade against a possibly stale index.
 - name: Install qt5ct
   ansible.builtin.apt:
     name: qt5ct
     state: latest
     allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
+    update_cache: true
+    cache_valid_time: 3600
   become: true
 
 - name: Install rsync
@@ -15,6 +19,8 @@
     name: rsync
     state: latest
     allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
+    update_cache: true
+    cache_valid_time: 3600
   become: true
 
 - name: Remove qt5ct from auto-start

--- a/ansible/roles/qt5ct_setup/tasks/main.yml
+++ b/ansible/roles/qt5ct_setup/tasks/main.yml
@@ -1,13 +1,19 @@
+# state: latest so an already-installed package is converged onto the pinned
+# version in locked mode; state: present would leave whatever the machine came
+# with, and the lockfile verification would then fail on a package no task
+# would ever move.
 - name: Install qt5ct
   ansible.builtin.apt:
     name: qt5ct
-    state: present
+    state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
   become: true
 
 - name: Install rsync
-  ansible.builtin.package:
+  ansible.builtin.apt:
     name: rsync
-    state: present
+    state: latest
+    allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"
   become: true
 
 - name: Remove qt5ct from auto-start

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -38,6 +38,12 @@
   ansible.builtin.import_tasks: snapshot_source.yaml
   when: use_locked_versions | default(false) | bool
 
+- name: Reconcile installed packages to the ROS snapshot (locked mode)
+  ansible.builtin.import_role:
+    name: autoware.dev_env.version_lock
+    tasks_from: reconcile
+  when: use_locked_versions | default(false) | bool
+
 - name: Hold check of ros-{{ rosdistro + '-' + ros2_installation_type }}
   ansible.builtin.command: apt-mark showhold
   register: ros2_held_ros_packages

--- a/ansible/roles/ros2_dev_tools/README.md
+++ b/ansible/roles/ros2_dev_tools/README.md
@@ -24,7 +24,10 @@ sudo apt update && sudo apt install -y \
   python3-flake8-quotes \
   python3-pytest-repeat \
   python3-pytest-rerunfailures \
-  ros-build-essential \
+  build-essential \
+  cmake \
+  git \
+  python3-setuptools \
   python3-bloom \
   python3-colcon-common-extensions \
   python3-colcon-mixin \

--- a/ansible/roles/ros2_dev_tools/README.md
+++ b/ansible/roles/ros2_dev_tools/README.md
@@ -1,6 +1,6 @@
 # ros2_dev_tools
 
-This role installs ROS 2 development tools following [this page](https://docs.ros.org/en/humble/Installation/Ubuntu-Development-Setup.html).
+This role installs ROS 2 development tools following [this page](https://docs.ros.org/en/humble/Installation/Alternatives/Ubuntu-Development-Setup.html).
 
 ## Inputs
 
@@ -9,7 +9,7 @@ None.
 ## Manual Installation
 
 ```bash
-# Taken from https://docs.ros.org/en/humble/Installation/Ubuntu-Development-Setup.html
+# Taken from https://docs.ros.org/en/humble/Installation/Alternatives/Ubuntu-Development-Setup.html
 sudo apt update && sudo apt install -y \
   python3-colcon-mixin \
   python3-flake8-docstrings \

--- a/ansible/roles/ros2_dev_tools/tasks/main.yaml
+++ b/ansible/roles/ros2_dev_tools/tasks/main.yaml
@@ -15,7 +15,14 @@
       - python3-flake8-quotes
       - python3-pytest-repeat
       - python3-pytest-rerunfailures
-      - ros-build-essential # from ros-dev-tools
+      # ros-build-essential's contents, inlined: the metapackage is served only
+      # by the rolling packages.ros.org repo and is absent from snapshots.ros.org,
+      # so locked mode cannot resolve it. Inlining also lets apt_pins freeze the
+      # actual tools. (python3 is omitted: it is always present.)
+      - build-essential
+      - cmake
+      - git
+      - python3-setuptools
       - python3-bloom # from ros-dev-tools
       - python3-colcon-common-extensions # from ros-dev-tools
       - python3-colcon-mixin # from ros-dev-tools

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -6,17 +6,22 @@
 - name: Assert the locked NVIDIA closure matches tensorrt_version
   ansible.builtin.assert:
     that:
-      - locked_packages.nvidia_pins.libnvinfer10 == tensorrt_version
+      - tensorrt__locked_libnvinfer10 == tensorrt_version
     fail_msg: >-
       Locked mode: the lockfile pins libnvinfer10 to
-      {{ locked_packages.nvidia_pins.libnvinfer10 }}, but this run requests
+      {{ tensorrt__locked_libnvinfer10 }}, but this run requests
       tensorrt_version={{ tensorrt_version }}. Point nvidia_lockfile_path at a
       closure recorded for this TensorRT version, or drop the tensorrt_version
       override.
     quiet: true
-  when:
-    - use_locked_versions | default(false) | bool
-    - (locked_packages.nvidia_pins | default({})).libnvinfer10 is defined
+  vars:
+    # "(none)" rather than skipping the assert: a closure with no libnvinfer10
+    # entry leaves the packages below unfrozen, which is exactly the case this
+    # assert exists to catch. locked_packages is always loaded first — every
+    # playbook that reaches this role imports version_lock as a pre_task
+    # tagged 'always'.
+    tensorrt__locked_libnvinfer10: "{{ (locked_packages.nvidia_pins | default({})).libnvinfer10 | default('(none)') }}"
+  when: use_locked_versions | default(false) | bool
 
 - name: Install TensorRT
   become: true

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -1,3 +1,23 @@
+# The TensorRT packages carry unversioned names, so a lockfile whose closure is
+# from another CUDA generation pins the very names installed below. Its pin and
+# the 1001 Ansible's apt module gives its own pkg=version request tie, apt keeps
+# the higher version, and the install fails with a bare "no available
+# installation candidate" that names neither the pin nor the lockfile.
+- name: Assert the locked NVIDIA closure matches tensorrt_version
+  ansible.builtin.assert:
+    that:
+      - locked_packages.nvidia_pins.libnvinfer10 == tensorrt_version
+    fail_msg: >-
+      Locked mode: the lockfile pins libnvinfer10 to
+      {{ locked_packages.nvidia_pins.libnvinfer10 }}, but this run requests
+      tensorrt_version={{ tensorrt_version }}. Point nvidia_lockfile_path at a
+      closure recorded for this TensorRT version, or drop the tensorrt_version
+      override.
+    quiet: true
+  when:
+    - use_locked_versions | default(false) | bool
+    - (locked_packages.nvidia_pins | default({})).libnvinfer10 is defined
+
 - name: Install TensorRT
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -22,6 +22,21 @@ To use a custom lockfile, override `lockfile_path`:
 ansible-playbook autoware.dev_env.install_dev_env --extra-vars "use_locked_versions=true lockfile_path=/path/to/my-lockfile.yaml" --ask-become-pass
 ```
 
+### Snapshot reconcile
+
+In locked mode the role does not only pin future installs: right after the
+dated snapshot source is configured, a reconcile step walks every **already
+installed** package that the snapshot serves at a different version back to
+the snapshot's version (`tasks/reconcile.yaml`, driven by
+`files/list_ros_snapshot_drift.py`). This matters most for Docker builds: the
+digest-pinned `ros:<distro>-ros-base` base image is built from a floating tag
+and is usually newer than `ros_snapshot_date`, so without the reconcile the
+final image would carry a hybrid ROS closure. The step is scoped to packages
+whose apt candidate originates from `snapshots.ros.org`; Ubuntu-archive
+packages are left at the digest-frozen base-image state plus explicit
+`apt_pins`. After all roles run, verification asserts the whole installed
+closure matches the snapshot (`tasks/verify.yaml`).
+
 ## Generating lockfiles
 
 On a machine already provisioned by `install_dev_env`, run:
@@ -57,6 +72,29 @@ The two generators are order-independent on an already-filled lockfile — `gene
 preserves `nvidia_pins` and this script preserves `apt_pins`/`pip_pins` — but both must run on a
 machine provisioned from the same snapshot date. On a lockfile that has no `ros_snapshot_date` yet,
 run `generate_ansible_lockfile.sh` first; this script refuses an unfilled lockfile.
+
+## When you add a new dependency
+
+Key insertion is the responsibility of the PR that changes a role; the
+`regenerate-lockfiles` workflow refreshes **values** of existing keys but
+never discovers new ones.
+
+| New dependency                                      | Lockfile action                                                                                                                       | Enforced by                                                               |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| ROS-repo package (`ros-*`, `python3-colcon-*`, ...) | none — `ros_snapshot_date` freezes it                                                                                                 | snapshot reconcile + closure verify                                       |
+| Ubuntu-archive package                              | add the key to `apt_pins` in **all four** lockfiles in the same PR (any current version; the next regeneration canonicalizes it)      | locked-mode verify fails listing unpinned newly-installed Ubuntu packages |
+| pip package                                         | add the key to `pip_pins` in the same PR                                                                                              | documented convention only                                                |
+| NVIDIA-repo package                                 | run `emit_nvidia_pins.py` on a machine after an unlocked `install_nvidia`; the regenerate workflow does **not** refresh `nvidia_pins` | documented convention only                                                |
+| Version refresh of existing keys                    | dispatch `regenerate-lockfiles.yaml` (updates lockfiles, snapshot dates, and base-image digests atomically)                           | `validate-lockfiles`                                                      |
+
+The Ubuntu-archive check's "Enforced by" only holds on a fresh host: it diffs
+`apt-mark showmanual` taken before any role runs against the same list taken
+after, so a package that is already manually installed going in — a rerun on
+a developer machine, or a Docker stage inheriting from one that installed it
+already — never shows up in the diff and slips past unchecked. Treat a green
+local run as covering only what was newly installed manual on that host, not
+as proof the lockfiles have no gaps; the check is reliable on the fresh
+containers CI builds from.
 
 ## Validating lockfiles
 

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -37,6 +37,13 @@ packages are left at the digest-frozen base-image state plus explicit
 `apt_pins`. After all roles run, verification asserts the whole installed
 closure matches the snapshot (`tasks/verify.yaml`).
 
+Packages under an `apt-mark hold` are **skipped** by both the reconcile and
+the closure assert, and listed in the play output. A hold is an explicit
+operator decision to keep one package where it is; apt refuses to act on a
+held package unless told to override the hold, so including one would abort
+the entire reconcile. The trade-off is that a held package is outside the
+freeze — release the hold if you want locked mode to govern it.
+
 ## Generating lockfiles
 
 On a machine already provisioned by `install_dev_env`, run:

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -77,7 +77,7 @@ tell an NVIDIA-repo package from an Ubuntu-archive one. On a machine that has ju
 completed an **unlocked** `install_nvidia`, run:
 
 ```bash
-sudo apt-get update
+sudo apt-get update && sudo apt-get install -y python3-apt python3-yaml   # the script imports both
 ./ansible/scripts/emit_nvidia_pins.py ansible/vars/locked-versions-<rosdistro>-<arch>.yaml
 ```
 

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -133,8 +133,9 @@ report either of them:
   install that includes `agnocast` therefore is not fully frozen.
 - **pip/pipx-managed packages.** `pip_pins` is currently empty and no role
   reads it. The pipx installs in `dev_tools` and `huggingface_cli`
-  (`pre-commit`, `clang-format`, `huggingface_hub`) and the venv installs in
-  `acados` all resolve to whatever PyPI serves at build time.
+  (`pre-commit`, `clang-format`, `huggingface_hub`) and the Python virtual
+  environment installs in `acados` all resolve to whatever the Python package
+  index serves at install time.
 
 Both are known gaps rather than oversights: closing them means changing how
 those roles install, which is out of scope for the lockfile mechanism itself.

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -32,7 +32,7 @@ ansible-playbook autoware.dev_env.install_nvidia \
   --extra-vars "nvidia_lockfile_path=/path/to/locked-nvidia-ubuntu2404-cuda12.8-amd64.yaml"
 ```
 
-The file needs only a top-level `nvidia_pins` mapping, in the same format as a lockfile's. It **replaces** `nvidia_pins` rather than merging into it, and `verify.yaml` then checks the substituted closure, so the pins stay exact and the freeze is unchanged — only the source file moves.
+The file needs only a top-level `nvidia_pins` mapping, in the same format as a lockfile's, and is produced the same way (`emit_nvidia_pins.py`, see below). It **replaces** `nvidia_pins` rather than merging into it, and `verify.yaml` then checks the substituted closure, so the pins stay exact and the freeze is unchanged — only the source file moves.
 
 Leaving `nvidia_lockfile_path` empty while overriding a version is not silently tolerated: the `cuda` role fails when no `cuda-*-<version>` entry covers this run, and the `tensorrt` role fails when the pinned `libnvinfer10` disagrees with `tensorrt_version`. Without those guards the CUDA half would install unfrozen (its version-suffixed names simply are not in the closure, and `verify.yaml` reports drift only for keys that are installed) and the TensorRT half would fail with an unattributable `no available installation candidate`.
 
@@ -93,6 +93,17 @@ The two generators are order-independent on an already-filled lockfile — `gene
 preserves `nvidia_pins` and this script preserves `apt_pins`/`pip_pins` — but both must run on a
 machine provisioned from the same snapshot date. On a lockfile that has no `ros_snapshot_date` yet,
 run `generate_ansible_lockfile.sh` first; this script refuses an unfilled lockfile.
+
+The same script records a **closure-only** file for `nvidia_lockfile_path`. Given a file whose only
+top-level key is `nvidia_pins` (an empty one, or one carrying just a header comment), it fills that
+key and leaves the file with no ROS sections — so a consumer's closure never carries a
+`ros_snapshot_date` it does not own. Run it on a machine provisioned with the `cuda_version` /
+`tensorrt_version` that file is meant to describe:
+
+```bash
+printf '# NVIDIA closure for ubuntu2404 / CUDA 12.8 / amd64\nnvidia_pins: {}\n' >closure.yaml
+./ansible/scripts/emit_nvidia_pins.py closure.yaml
+```
 
 ## When you add a new dependency
 

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -92,6 +92,7 @@ never discovers new ones.
 | Ubuntu-archive package                              | add the key to `apt_pins` in **all four** lockfiles in the same PR (any current version; the next regeneration canonicalizes it)      | locked-mode verify fails listing unpinned newly-installed Ubuntu packages |
 | pip package                                         | add the key to `pip_pins` in the same PR                                                                                              | documented convention only                                                |
 | NVIDIA-repo package                                 | run `emit_nvidia_pins.py` on a machine after an unlocked `install_nvidia`; the regenerate workflow does **not** refresh `nvidia_pins` | documented convention only                                                |
+| Third-party apt repo package (PPA, vendor repo)     | no lockfile section covers it — see "What the freeze does not cover" below                                                            | nothing                                                                   |
 | Version refresh of existing keys                    | dispatch `regenerate-lockfiles.yaml` (updates lockfiles, snapshot dates, and base-image digests atomically)                           | `validate-lockfiles`                                                      |
 
 The Ubuntu-archive check's "Enforced by" only holds on a fresh host: it diffs
@@ -116,6 +117,27 @@ are exempt from the check. `agnocast` installs `linux-headers-{{ ansible_kernel 
 on bare metal; its name varies per machine and changes on every kernel upgrade,
 so no static lockfile key could cover it. It is a host property, not a
 dependency of Autoware, and freezing it is neither possible nor desirable.
+
+### What the freeze does not cover
+
+The table above is not a complete inventory of what an install pulls in. Two
+categories sit outside the freeze today, and the completeness check does not
+report either of them:
+
+- **Third-party apt repositories.** The check only reports packages whose
+  installed version carries `Origin: Ubuntu`, so a package from any other
+  origin passes silently. The live case is `agnocast`, which installs its
+  heaphook package from a Launchpad PPA (`Origin: LP-PPA-...`) with
+  `state: present`: top-level, version-floating, and covered by none of
+  `ros_snapshot_date`, `apt_pins`, `nvidia_pins`, or `pip_pins`. A locked
+  install that includes `agnocast` therefore is not fully frozen.
+- **pip/pipx-managed packages.** `pip_pins` is currently empty and no role
+  reads it. The pipx installs in `dev_tools` and `huggingface_cli`
+  (`pre-commit`, `clang-format`, `huggingface_hub`) and the venv installs in
+  `acados` all resolve to whatever PyPI serves at build time.
+
+Both are known gaps rather than oversights: closing them means changing how
+those roles install, which is out of scope for the lockfile mechanism itself.
 
 ## Validating lockfiles
 
@@ -157,8 +179,10 @@ ros_overrides: {} # exception pins for individual ROS packages; normally empty
   otherwise both sit at priority 500 and apt would install the newer rolling build.
 - `apt_pins` covers Ubuntu-archive packages. It is rendered into `/etc/apt/preferences.d/autoware-lock`
   with `Pin-Priority: 1001`.
-- `pip_pins` covers pip/pipx-managed packages. It is consumed directly by the
-  relevant roles and is **not** rendered as APT pins.
+- `pip_pins` is the declared home for pip/pipx-managed packages. It is meant to be consumed
+  directly by the relevant roles and is **not** rendered as APT pins. It is currently `{}` in
+  every lockfile and no role reads it: `gdown`, its last consumer, was removed. See "What the
+  freeze does not cover" for the pip/pipx installs that remain unpinned.
 - `nvidia_pins` covers the CUDA/TensorRT closure from NVIDIA's apt repo, rendered into
   `/etc/apt/preferences.d/autoware-lock` with `Pin-Priority: 1001` like `apt_pins`. It is a
   separate section because NVIDIA publishes no dated snapshot to freeze against — its repo is

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -126,11 +126,15 @@ report either of them:
 
 - **Third-party apt repositories.** The check only reports packages whose
   installed version carries `Origin: Ubuntu`, so a package from any other
-  origin passes silently. The live case is `agnocast`, which installs its
-  heaphook package from a Launchpad PPA (`Origin: LP-PPA-...`) with
-  `state: present`: top-level, version-floating, and covered by none of
-  `ros_snapshot_date`, `apt_pins`, `nvidia_pins`, or `pip_pins`. A locked
-  install that includes `agnocast` therefore is not fully frozen.
+  origin passes silently. There are two live cases, both installed top-level
+  with `state: present` and covered by none of `ros_snapshot_date`,
+  `apt_pins`, `nvidia_pins`, or `pip_pins`. `agnocast` installs its heaphook
+  package from a Launchpad PPA (`Origin: LP-PPA-...`). `cuda` installs the
+  `nvidia-open` driver metapackage from NVIDIA's apt repository
+  (`developer.download.nvidia.com`) when `cuda_install_drivers=true`;
+  `nvidia_pins` freezes the CUDA toolkit and TensorRT packages that role names
+  explicitly, not the driver. A locked install that runs either role is
+  therefore not fully frozen.
 - **pip/pipx-managed packages.** `pip_pins` is currently empty and no role
   reads it. The pipx installs in `dev_tools` and `huggingface_cli`
   (`pre-commit`, `clang-format`, `huggingface_hub`) and the Python virtual

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -22,6 +22,20 @@ To use a custom lockfile, override `lockfile_path`:
 ansible-playbook autoware.dev_env.install_dev_env --extra-vars "use_locked_versions=true lockfile_path=/path/to/my-lockfile.yaml" --ask-become-pass
 ```
 
+#### Overriding only the NVIDIA closure
+
+`(rosdistro, arch)` does not identify the CUDA/TensorRT closure. That closure is a function of `(cuda_repo_distro, cuda_version, tensorrt_version, arch)`, and the `cuda` and `tensorrt` roles let a consumer override all four — so `locked-versions-<rosdistro>-<arch>.yaml` can only carry the generation those roles default to for that distro (CUDA 13.0 on 24.04, 12.8 on 22.04). A consumer that overrides `cuda_version` or `tensorrt_version` must supply the matching closure through `nvidia_lockfile_path`:
+
+```bash
+ansible-playbook autoware.dev_env.install_nvidia \
+  --extra-vars "use_locked_versions=true cuda_version=12.8 tensorrt_version=10.8.0.43-1+cuda12.8" \
+  --extra-vars "nvidia_lockfile_path=/path/to/locked-nvidia-ubuntu2404-cuda12.8-amd64.yaml"
+```
+
+The file needs only a top-level `nvidia_pins` mapping, in the same format as a lockfile's. It **replaces** `nvidia_pins` rather than merging into it, and `verify.yaml` then checks the substituted closure, so the pins stay exact and the freeze is unchanged — only the source file moves.
+
+Leaving `nvidia_lockfile_path` empty while overriding a version is not silently tolerated: the `cuda` role fails when no `cuda-*-<version>` entry covers this run, and the `tensorrt` role fails when the pinned `libnvinfer10` disagrees with `tensorrt_version`. Without those guards the CUDA half would install unfrozen (its version-suffixed names simply are not in the closure, and `verify.yaml` reports drift only for keys that are installed) and the TensorRT half would fail with an unattributable `no available installation candidate`.
+
 ### Snapshot reconcile
 
 In locked mode the role does not only pin future installs: right after the

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -111,6 +111,12 @@ already-installed package, so on a pre-provisioned machine the pin would never
 be applied while the verification still fails on the mismatch, with advice the
 user cannot act on. Pin only what a task actually moves.
 
+Kernel-coupled packages (`linux-headers-*`, `linux-image-*`, `linux-modules-*`)
+are exempt from the check. `agnocast` installs `linux-headers-{{ ansible_kernel }}`
+on bare metal; its name varies per machine and changes on every kernel upgrade,
+so no static lockfile key could cover it. It is a host property, not a
+dependency of Autoware, and freezing it is neither possible nor desirable.
+
 ## Validating lockfiles
 
 ```bash

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -103,6 +103,14 @@ local run as covering only what was newly installed manual on that host, not
 as proof the lockfiles have no gaps; the check is reliable on the fresh
 containers CI builds from.
 
+A key in `apt_pins` also obliges the task that installs the package to
+**converge** it — `state: latest` with
+`allow_downgrade: "{{ use_locked_versions | default(false) | bool }}"`, the
+idiom `ros2_dev_tools` uses. `state: present` is a no-op on an
+already-installed package, so on a pre-provisioned machine the pin would never
+be applied while the verification still fails on the mismatch, with advice the
+user cannot act on. Pin only what a task actually moves.
+
 ## Validating lockfiles
 
 ```bash

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -28,9 +28,11 @@ ansible-playbook autoware.dev_env.install_dev_env --extra-vars "use_locked_versi
 
 ```bash
 ansible-playbook autoware.dev_env.install_nvidia \
-  --extra-vars "use_locked_versions=true cuda_version=12.8 tensorrt_version=10.8.0.43-1+cuda12.8" \
+  --extra-vars "rosdistro=jazzy use_locked_versions=true cuda_version=12.8 tensorrt_version=10.8.0.43-1+cuda12.8" \
   --extra-vars "nvidia_lockfile_path=/path/to/locked-nvidia-ubuntu2404-cuda12.8-amd64.yaml"
 ```
+
+`rosdistro` is required even though the closure does not depend on it: unlike `install_dev_env`, the `install_nvidia` playbook does not define it, and `lockfile_path` — loaded before `nvidia_lockfile_path` is consulted — interpolates it. (`base-cuda.Dockerfile` passes it, which is why the Docker path needs no such note.)
 
 The file needs only a top-level `nvidia_pins` mapping, in the same format as a lockfile's, and is produced the same way (`emit_nvidia_pins.py`, see below). It **replaces** `nvidia_pins` rather than merging into it, and `verify.yaml` then checks the substituted closure, so the pins stay exact and the freeze is unchanged — only the source file moves.
 
@@ -77,9 +79,11 @@ tell an NVIDIA-repo package from an Ubuntu-archive one. On a machine that has ju
 completed an **unlocked** `install_nvidia`, run:
 
 ```bash
-sudo apt-get update && sudo apt-get install -y python3-apt python3-yaml   # the script imports both
+sudo apt-get update && sudo apt-get install -y python3-yaml   # the only non-stdlib import
 ./ansible/scripts/emit_nvidia_pins.py ansible/vars/locked-versions-<rosdistro>-<arch>.yaml
 ```
+
+Unlike the `files/*.py` the role runs, this script needs no `python3-apt`: it shells out to `apt-get indextargets`, `apt-helper cat-file` and `dpkg-query` rather than using the apt bindings.
 
 <!-- cspell:ignore indextargets -->
 
@@ -151,10 +155,11 @@ report either of them:
 
 - **Third-party apt repositories.** The check only reports packages whose
   installed version carries `Origin: Ubuntu`, so a package from any other
-  origin passes silently. There are two live cases, both installed top-level
+  origin passes silently. There are three live cases, all installed top-level
   with `state: present` and covered by none of `ros_snapshot_date`,
-  `apt_pins`, `nvidia_pins`, or `pip_pins`. `agnocast` installs its heaphook
-  package from a Launchpad PPA (`Origin: LP-PPA-...`). `cuda` installs the
+  `apt_pins`, `nvidia_pins`, or `pip_pins`. `agnocast` installs two packages
+  from a Launchpad PPA (`Origin: LP-PPA-...`): its heaphook package, and
+  `agnocast_kmod_package` on any non-container host. `cuda` installs the
   `nvidia-open` driver metapackage from NVIDIA's apt repository
   (`developer.download.nvidia.com`) when `cuda_install_drivers=true`;
   `nvidia_pins` freezes the CUDA toolkit and TensorRT packages that role names

--- a/ansible/roles/version_lock/README.md
+++ b/ansible/roles/version_lock/README.md
@@ -170,8 +170,26 @@ report either of them:
   (`pre-commit`, `clang-format`, `huggingface_hub`) and the Python virtual
   environment installs in `acados` all resolve to whatever the Python package
   index serves at install time.
+- **ROS packages the snapshot does not serve at all.** `ros_snapshot_date`
+  freezes the packages the dated snapshot carries. The rolling
+  `packages.ros.org` source stays configured in locked mode, so a `ros-*`
+  package absent from the snapshot still installs from rolling, at the default
+  priority 500 — the `Pin: origin snapshots.ros.org` wildcard cannot apply to a
+  package that origin does not offer. This is not hypothetical: the noble
+  rolling index carries 71 `ros-jazzy-autoware-*` names the 2026-04-13 snapshot
+  lacks, and `core.Dockerfile` deletes the `autoware_core` and
+  `autoware_rviz_plugins` `package.xml` precisely so their dependencies resolve
+  from apt. The closure verify does not report them either: it compares against
+  packages whose apt _candidate_ comes from the snapshot, and theirs does not.
+- **Packages installed outside the roles.** The completeness check diffs
+  `apt-mark showmanual` across the play, so anything installed before
+  `version_lock` runs is invisible to it as well as unpinned — including the
+  packages `docker/base.Dockerfile` installs with a raw `apt-get` before the pin
+  file exists. Transitive Ubuntu dependencies are not checked either (only
+  top-level installs are), nor are the packages the ten `rosdep install` call
+  sites resolve.
 
-Both are known gaps rather than oversights: closing them means changing how
+These are known gaps rather than oversights: closing them means changing how
 those roles install, which is out of scope for the lockfile mechanism itself.
 
 ## Validating lockfiles

--- a/ansible/roles/version_lock/defaults/main.yaml
+++ b/ansible/roles/version_lock/defaults/main.yaml
@@ -3,3 +3,11 @@ version_lock_arch_map:
   aarch64: arm64
 # lockfile_path is the published interface-contract variable; renaming would break consumers.
 lockfile_path: "{{ role_path }}/../../vars/locked-versions-{{ rosdistro }}-{{ version_lock_arch_map[ansible_architecture] | default(ansible_architecture) }}.yaml" # noqa: var-naming[no-role-prefix]
+# Optional path to a file whose nvidia_pins describe the CUDA/TensorRT closure
+# THIS run installs. That closure is a function of (cuda_repo_distro,
+# cuda_version, tensorrt_version, arch) and not of rosdistro, so
+# locked-versions-<rosdistro>-<arch>.yaml can only carry the generation the
+# cuda/tensorrt role defaults pick for that distro. A consumer overriding
+# cuda_version or tensorrt_version must point this at its own closure file.
+# Empty means: use the nvidia_pins in lockfile_path.
+nvidia_lockfile_path: "" # noqa: var-naming[no-role-prefix]

--- a/ansible/roles/version_lock/files/check_pin_completeness.py
+++ b/ansible/roles/version_lock/files/check_pin_completeness.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Filter package names to those installed from the Ubuntu archive.
+
+Reads package names (one per line) on stdin and prints the ones whose
+installed version carries a Release "Origin: Ubuntu" — i.e. packages that a
+locked install must have an apt_pins entry for. ROS-repo (Origin: ROS) and
+NVIDIA-repo packages are excluded: the dated snapshot and nvidia_pins freeze
+those. Used by the locked-mode pin-completeness check in verify.yaml.
+"""
+
+import sys
+
+import apt
+
+
+def main() -> None:
+    names = [line.strip() for line in sys.stdin if line.strip()]
+    cache = apt.Cache()
+    for name in names:
+        if name not in cache:
+            continue
+        pkg = cache[name]
+        if not pkg.is_installed:
+            continue
+        if any(o.origin == "Ubuntu" for o in pkg.installed.origins):
+            print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/version_lock/files/check_pin_completeness.py
+++ b/ansible/roles/version_lock/files/check_pin_completeness.py
@@ -6,17 +6,27 @@ installed version carries a Release "Origin: Ubuntu" — i.e. packages that a
 locked install must have an apt_pins entry for. ROS-repo (Origin: ROS) and
 NVIDIA-repo packages are excluded: the dated snapshot and nvidia_pins freeze
 those. Used by the locked-mode pin-completeness check in verify.yaml.
+
+Kernel-coupled packages (linux-headers-*, linux-image-*, linux-modules-*) are
+also excluded. The agnocast role installs linux-headers-{{ ansible_kernel }}
+on bare metal, whose name varies per machine and changes on every kernel
+upgrade, so no static lockfile key could ever cover it.
 """
 
+import re
 import sys
 
 import apt
+
+KERNEL_COUPLED = re.compile(r"^linux-(headers|image|modules)-")
 
 
 def main() -> None:
     names = [line.strip() for line in sys.stdin if line.strip()]
     cache = apt.Cache()
     for name in names:
+        if KERNEL_COUPLED.match(name):
+            continue
         if name not in cache:
             continue
         pkg = cache[name]

--- a/ansible/roles/version_lock/files/list_ros_snapshot_drift.py
+++ b/ansible/roles/version_lock/files/list_ros_snapshot_drift.py
@@ -8,24 +8,42 @@ installed. Scoping to snapshot-origin candidates keeps the reconcile step from
 touching Ubuntu-archive packages: those are frozen by the base-image digest
 plus explicit apt_pins, and moving them would break that freeze.
 
+Packages under an `apt-mark hold` are skipped and reported on stderr instead:
+a hold is an explicit operator decision, and apt refuses to act on a held
+package unless told to override the hold, which would abort the whole
+reconcile over one package the user deliberately froze.
+
 Requires python3-apt (already required by Ansible's apt module) and an
 up-to-date apt cache.
 """
 
+import sys
+
 import apt
+import apt_pkg
 
 SNAPSHOT_SITE = "snapshots.ros.org"
 
 
 def main() -> None:
     cache = apt.Cache()
+    held = []
     for pkg in cache:
         if not pkg.is_installed or pkg.candidate is None:
             continue
         if pkg.candidate.version == pkg.installed.version:
             continue
-        if any(o.site == SNAPSHOT_SITE for o in pkg.candidate.origins):
-            print(f"{pkg.name}={pkg.candidate.version}")
+        if not any(o.site == SNAPSHOT_SITE for o in pkg.candidate.origins):
+            continue
+        if pkg._pkg.selected_state == apt_pkg.SELSTATE_HOLD:
+            held.append(pkg.name)
+            continue
+        print(f"{pkg.name}={pkg.candidate.version}")
+    if held:
+        print(
+            "skipped (apt-mark hold): " + " ".join(sorted(held)),
+            file=sys.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/ansible/roles/version_lock/files/list_ros_snapshot_drift.py
+++ b/ansible/roles/version_lock/files/list_ros_snapshot_drift.py
@@ -13,7 +13,7 @@ a hold is an explicit operator decision, and apt refuses to act on a held
 package unless told to override the hold, which would abort the whole
 reconcile over one package the user deliberately froze.
 
-Requires python3-apt (already required by Ansible's apt module) and an
+Requires python3-apt (installed by this role's tasks/main.yaml) and an
 up-to-date apt cache.
 """
 

--- a/ansible/roles/version_lock/files/list_ros_snapshot_drift.py
+++ b/ansible/roles/version_lock/files/list_ros_snapshot_drift.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""List installed packages diverging from the dated ROS snapshot.
+
+Prints one "name=candidate_version" line for every installed package whose
+apt candidate comes from snapshots.ros.org (the dated snapshot configured in
+locked mode, pinned to priority 1001) at a version different from the one
+installed. Scoping to snapshot-origin candidates keeps the reconcile step from
+touching Ubuntu-archive packages: those are frozen by the base-image digest
+plus explicit apt_pins, and moving them would break that freeze.
+
+Requires python3-apt (already required by Ansible's apt module) and an
+up-to-date apt cache.
+"""
+
+import apt
+
+SNAPSHOT_SITE = "snapshots.ros.org"
+
+
+def main() -> None:
+    cache = apt.Cache()
+    for pkg in cache:
+        if not pkg.is_installed or pkg.candidate is None:
+            continue
+        if pkg.candidate.version == pkg.installed.version:
+            continue
+        if any(o.site == SNAPSHOT_SITE for o in pkg.candidate.origins):
+            print(f"{pkg.name}={pkg.candidate.version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/version_lock/tasks/main.yaml
+++ b/ansible/roles/version_lock/tasks/main.yaml
@@ -29,6 +29,21 @@
     state: absent
   when: not (use_locked_versions | default(false) | bool)
 
+# Both files/list_ros_snapshot_drift.py and files/check_pin_completeness.py
+# `import apt`, so python3-apt is a declared dependency of this role, not
+# incidental bootstrap. Installing it explicitly, before the baseline below,
+# serves two purposes: it converges onto the pinned version (Ansible's apt
+# module would otherwise self-heal it at whatever apt offers), and it keeps it
+# out of the before/after diff that drives the pin-completeness check.
+- name: Install python3-apt for the version_lock scripts
+  become: true
+  ansible.builtin.apt:
+    name: python3-apt
+    state: latest
+    allow_downgrade: true
+    update_cache: true
+  when: use_locked_versions | default(false) | bool
+
 # Baseline for the pin-completeness check in verify.yaml: whatever is
 # top-level ("manual") before any role runs. Packages the play later installs
 # top-level from the Ubuntu archive must appear in apt_pins; the generator

--- a/ansible/roles/version_lock/tasks/main.yaml
+++ b/ansible/roles/version_lock/tasks/main.yaml
@@ -14,6 +14,37 @@
       The lockfile may be an unfilled arm64 template.
   when: use_locked_versions | default(false) | bool
 
+- name: Load the consumer-supplied NVIDIA closure
+  ansible.builtin.include_vars:
+    file: "{{ nvidia_lockfile_path }}"
+    name: version_lock_nvidia
+  when:
+    - use_locked_versions | default(false) | bool
+    - nvidia_lockfile_path | length > 0
+
+- name: Assert the consumer-supplied NVIDIA closure provides nvidia_pins
+  ansible.builtin.assert:
+    that:
+      - version_lock_nvidia.nvidia_pins is defined
+      - version_lock_nvidia.nvidia_pins | length > 0
+    fail_msg: >-
+      nvidia_lockfile_path={{ nvidia_lockfile_path }} must define a non-empty
+      'nvidia_pins' mapping.
+  when:
+    - use_locked_versions | default(false) | bool
+    - nvidia_lockfile_path | length > 0
+
+# Substituted, not merged: a consumer supplies its own closure precisely because
+# it installs a different CUDA generation, so keeping the lockfile's own entries
+# would pin packages this run never installs — and, for the unversioned TensorRT
+# names, would pin them to the wrong generation.
+- name: Substitute the consumer-supplied NVIDIA closure # noqa: var-naming[no-role-prefix]
+  ansible.builtin.set_fact:
+    locked_packages: "{{ locked_packages | combine({'nvidia_pins': version_lock_nvidia.nvidia_pins}) }}"
+  when:
+    - use_locked_versions | default(false) | bool
+    - nvidia_lockfile_path | length > 0
+
 - name: Create APT version pins
   become: true
   ansible.builtin.template:

--- a/ansible/roles/version_lock/tasks/main.yaml
+++ b/ansible/roles/version_lock/tasks/main.yaml
@@ -28,3 +28,14 @@
     path: /etc/apt/preferences.d/autoware-lock
     state: absent
   when: not (use_locked_versions | default(false) | bool)
+
+# Baseline for the pin-completeness check in verify.yaml: whatever is
+# top-level ("manual") before any role runs. Packages the play later installs
+# top-level from the Ubuntu archive must appear in apt_pins; the generator
+# only refreshes keys that already exist, so a forgotten key would otherwise
+# float silently in locked mode.
+- name: Record manually-installed packages before roles run
+  ansible.builtin.command: apt-mark showmanual
+  register: version_lock_manual_before
+  changed_when: false
+  when: use_locked_versions | default(false) | bool

--- a/ansible/roles/version_lock/tasks/reconcile.yaml
+++ b/ansible/roles/version_lock/tasks/reconcile.yaml
@@ -22,6 +22,13 @@
   register: version_lock_reconcile_list
   changed_when: false
 
+# The enumerator drops held packages rather than aborting the whole reconcile
+# on them; say so out loud, because their versions are then outside the freeze.
+- name: Report packages the reconcile skipped because they are held
+  ansible.builtin.debug:
+    msg: "{{ version_lock_reconcile_list.stderr_lines }}"
+  when: version_lock_reconcile_list.stderr | length > 0
+
 - name: Reconcile diverging packages to the snapshot versions
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/version_lock/tasks/reconcile.yaml
+++ b/ansible/roles/version_lock/tasks/reconcile.yaml
@@ -7,8 +7,7 @@
 # unpinned Ubuntu-archive packages past the digest-frozen base-image state.
 # Callers import this file guarded by `when: use_locked_versions`.
 #
-# The apt update below also guarantees python3-apt is present (the apt module
-# installs it on first use), which the enumerator script needs.
+# python3-apt, which the enumerator script needs, is installed by main.yaml.
 - name: Update apt cache so snapshot candidates are visible
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/version_lock/tasks/reconcile.yaml
+++ b/ansible/roles/version_lock/tasks/reconcile.yaml
@@ -1,0 +1,31 @@
+# Walk every installed package that the dated ROS snapshot serves at a
+# different version back to the snapshot's version. This matters when packages
+# were installed before the snapshot source existed — above all the ROS closure
+# preinstalled in the ros:<distro>-ros-base base image, whose floating tag is
+# usually newer than the lockfile's ros_snapshot_date. Scoped to
+# snapshot-origin candidates only: a blanket dist-upgrade would also advance
+# unpinned Ubuntu-archive packages past the digest-frozen base-image state.
+# Callers import this file guarded by `when: use_locked_versions`.
+#
+# The apt update below also guarantees python3-apt is present (the apt module
+# installs it on first use), which the enumerator script needs.
+- name: Update apt cache so snapshot candidates are visible
+  become: true
+  ansible.builtin.apt:
+    update_cache: true
+
+- name: List installed packages diverging from the ROS snapshot
+  ansible.builtin.command:
+    argv:
+      - python3
+      - "{{ role_path }}/files/list_ros_snapshot_drift.py"
+  register: version_lock_reconcile_list
+  changed_when: false
+
+- name: Reconcile diverging packages to the snapshot versions
+  become: true
+  ansible.builtin.apt:
+    name: "{{ version_lock_reconcile_list.stdout_lines }}"
+    state: present
+    allow_downgrade: true
+  when: version_lock_reconcile_list.stdout_lines | length > 0

--- a/ansible/roles/version_lock/tasks/reconcile.yaml
+++ b/ansible/roles/version_lock/tasks/reconcile.yaml
@@ -8,6 +8,13 @@
 # Callers import this file guarded by `when: use_locked_versions`.
 #
 # python3-apt, which the enumerator script needs, is installed by main.yaml.
+# The interpreter is named absolutely rather than as a bare `python3`: the
+# latter resolves from the invoking user's PATH, and any active venv shadows
+# the system interpreter that python3-apt installs into. Templating
+# `ansible_python_interpreter` instead would be worse — on the implicit
+# localhost these plays run against, Ansible sets it to its own sys.executable,
+# and Autoware installs Ansible with pipx (scripts/install-ansible.sh,
+# docker/base.Dockerfile), so it always points at a venv with no apt bindings.
 - name: Update apt cache so snapshot candidates are visible
   become: true
   ansible.builtin.apt:
@@ -16,7 +23,7 @@
 - name: List installed packages diverging from the ROS snapshot
   ansible.builtin.command:
     argv:
-      - python3
+      - /usr/bin/python3
       - "{{ role_path }}/files/list_ros_snapshot_drift.py"
   register: version_lock_reconcile_list
   changed_when: false

--- a/ansible/roles/version_lock/tasks/verify.yaml
+++ b/ansible/roles/version_lock/tasks/verify.yaml
@@ -73,3 +73,40 @@
           {{ version_lock_closure_drift.stdout_lines | join('\n') }}
         success_msg: ROS closure matches the {{ locked_packages.ros_snapshot_date }} snapshot.
         quiet: true
+
+    - name: List manually-installed packages after roles ran
+      ansible.builtin.command: apt-mark showmanual
+      register: version_lock_manual_after
+      changed_when: false
+      when: version_lock_manual_before is defined
+
+    - name: Identify packages this run installed top-level from the Ubuntu archive
+      ansible.builtin.command:
+        argv:
+          - python3
+          - "{{ role_path }}/files/check_pin_completeness.py"
+      args:
+        stdin: >-
+          {{ version_lock_manual_after.stdout_lines
+             | difference(version_lock_manual_before.stdout_lines)
+             | join('\n') }}
+      register: version_lock_new_ubuntu_pkgs
+      changed_when: false
+      when: version_lock_manual_before is defined
+
+    - name: Fail if a newly-installed Ubuntu package has no apt_pins entry
+      ansible.builtin.assert:
+        that: version_lock_missing_pins | length == 0
+        fail_msg: |-
+          Locked mode installed top-level Ubuntu-archive packages that have no
+          apt_pins entry, so their versions are not frozen. Add them to every
+          ansible/vars/locked-versions-*.yaml (the regenerate workflow refreshes
+          values but never discovers new keys):
+          {{ version_lock_missing_pins | join('\n') }}
+        success_msg: All newly-installed Ubuntu packages are covered by apt_pins.
+        quiet: true
+      vars:
+        version_lock_missing_pins: >-
+          {{ version_lock_new_ubuntu_pkgs.stdout_lines | default([])
+             | difference((locked_packages.apt_pins | default({})).keys() | list) }}
+      when: version_lock_manual_before is defined

--- a/ansible/roles/version_lock/tasks/verify.yaml
+++ b/ansible/roles/version_lock/tasks/verify.yaml
@@ -65,6 +65,13 @@
       register: version_lock_closure_drift
       changed_when: false
 
+    # Held packages are excluded from the closure assert below, so name them:
+    # a hold is the one supported way to keep a package outside the freeze.
+    - name: Report packages the closure check skipped because they are held
+      ansible.builtin.debug:
+        msg: "{{ version_lock_closure_drift.stderr_lines }}"
+      when: version_lock_closure_drift.stderr | length > 0
+
     - name: Fail if any installed package diverged from the ROS snapshot
       ansible.builtin.assert:
         that: version_lock_closure_drift.stdout_lines | length == 0

--- a/ansible/roles/version_lock/tasks/verify.yaml
+++ b/ansible/roles/version_lock/tasks/verify.yaml
@@ -57,10 +57,12 @@
     # installed package may diverge from what the dated snapshot serves
     # (reconcile ran earlier; fresh installs always take the 1001-pinned
     # snapshot candidate, so any hit here means the freeze is broken).
+    # See reconcile.yaml for why the interpreter is /usr/bin/python3 and not a
+    # bare `python3` or a templated ansible_python_interpreter.
     - name: Re-check installed packages against the ROS snapshot
       ansible.builtin.command:
         argv:
-          - python3
+          - /usr/bin/python3
           - "{{ role_path }}/files/list_ros_snapshot_drift.py"
       register: version_lock_closure_drift
       changed_when: false
@@ -96,7 +98,7 @@
     - name: Identify packages this run installed top-level from the Ubuntu archive
       ansible.builtin.command:
         argv:
-          - python3
+          - /usr/bin/python3
           - "{{ role_path }}/files/check_pin_completeness.py"
       args:
         # A folded YAML block scalar (>-) does not decode backslash escapes, so

--- a/ansible/roles/version_lock/tasks/verify.yaml
+++ b/ansible/roles/version_lock/tasks/verify.yaml
@@ -70,9 +70,15 @@
         that: version_lock_closure_drift.stdout_lines | length == 0
         fail_msg: |-
           Installed packages diverge from the {{ locked_packages.ros_snapshot_date }} ROS snapshot:
-          {{ version_lock_closure_drift.stdout_lines | join('\n') }}
+          {{ version_lock_closure_drift_lines }}
         success_msg: ROS closure matches the {{ locked_packages.ros_snapshot_date }} snapshot.
         quiet: true
+      vars:
+        # A folded/literal YAML block scalar leaves join('\n') as a literal
+        # backslash-n, not a real newline (only YAML's own double-quoted-scalar
+        # escape processing decodes \n before Jinja sees it). Precompute the
+        # joined text in a double-quoted var so fail_msg renders one item per line.
+        version_lock_closure_drift_lines: "{{ version_lock_closure_drift.stdout_lines | join(\"\n\") }}"
 
     - name: List manually-installed packages after roles ran
       ansible.builtin.command: apt-mark showmanual
@@ -86,10 +92,13 @@
           - python3
           - "{{ role_path }}/files/check_pin_completeness.py"
       args:
-        stdin: >-
-          {{ version_lock_manual_after.stdout_lines
-             | difference(version_lock_manual_before.stdout_lines)
-             | join('\n') }}
+        # A folded YAML block scalar (>-) does not decode backslash escapes, so
+        # join('\n') would reach the script as a literal backslash-n and never
+        # split into lines. A double-quoted scalar lets YAML's own \n escape
+        # produce a real newline before Jinja evaluates the expression.
+        stdin: "{{ version_lock_manual_after.stdout_lines
+          | difference(version_lock_manual_before.stdout_lines)
+          | join(\"\n\") }}"
       register: version_lock_new_ubuntu_pkgs
       changed_when: false
       when: version_lock_manual_before is defined
@@ -102,11 +111,15 @@
           apt_pins entry, so their versions are not frozen. Add them to every
           ansible/vars/locked-versions-*.yaml (the regenerate workflow refreshes
           values but never discovers new keys):
-          {{ version_lock_missing_pins | join('\n') }}
+          {{ version_lock_missing_pins_lines }}
         success_msg: All newly-installed Ubuntu packages are covered by apt_pins.
         quiet: true
       vars:
         version_lock_missing_pins: >-
           {{ version_lock_new_ubuntu_pkgs.stdout_lines | default([])
              | difference((locked_packages.apt_pins | default({})).keys() | list) }}
+        # See the note on the "diverged from the ROS snapshot" assert above:
+        # fail_msg is a literal block scalar, so join('\n') must be precomputed
+        # in a double-quoted var to get real newlines instead of "\n" text.
+        version_lock_missing_pins_lines: "{{ version_lock_missing_pins | join(\"\n\") }}"
       when: version_lock_manual_before is defined

--- a/ansible/roles/version_lock/tasks/verify.yaml
+++ b/ansible/roles/version_lock/tasks/verify.yaml
@@ -48,9 +48,15 @@
           Locked mode installed versions that differ from the lockfile. The pinned
           version was unreachable in the configured sources, so apt fell back to
           another candidate. Refresh the lockfile or ros_snapshot_date:
-          {{ version_lock_drift | default([]) | join('\n') }}
+          {{ version_lock_drift_lines }}
         success_msg: All {{ version_lock_expected | length }} pinned packages match the lockfile.
         quiet: true
+      vars:
+        # quiet: true suppresses per-item output, so this fail_msg is the only
+        # place the drift list is shown. As at the three sites below, a literal
+        # block scalar leaves join('\n') as backslash-n, so precompute the
+        # joined text in a double-quoted var to get real newlines.
+        version_lock_drift_lines: "{{ version_lock_drift | default([]) | join(\"\n\") }}"
 
     # The asserts above cover only packages listed in the lockfile. The two
     # tasks below cover the ROS closure as a whole: after every role ran, no

--- a/ansible/roles/version_lock/tasks/verify.yaml
+++ b/ansible/roles/version_lock/tasks/verify.yaml
@@ -51,3 +51,25 @@
           {{ version_lock_drift | default([]) | join('\n') }}
         success_msg: All {{ version_lock_expected | length }} pinned packages match the lockfile.
         quiet: true
+
+    # The asserts above cover only packages listed in the lockfile. The two
+    # tasks below cover the ROS closure as a whole: after every role ran, no
+    # installed package may diverge from what the dated snapshot serves
+    # (reconcile ran earlier; fresh installs always take the 1001-pinned
+    # snapshot candidate, so any hit here means the freeze is broken).
+    - name: Re-check installed packages against the ROS snapshot
+      ansible.builtin.command:
+        argv:
+          - python3
+          - "{{ role_path }}/files/list_ros_snapshot_drift.py"
+      register: version_lock_closure_drift
+      changed_when: false
+
+    - name: Fail if any installed package diverged from the ROS snapshot
+      ansible.builtin.assert:
+        that: version_lock_closure_drift.stdout_lines | length == 0
+        fail_msg: |-
+          Installed packages diverge from the {{ locked_packages.ros_snapshot_date }} ROS snapshot:
+          {{ version_lock_closure_drift.stdout_lines | join('\n') }}
+        success_msg: ROS closure matches the {{ locked_packages.ros_snapshot_date }} snapshot.
+        quiet: true

--- a/ansible/scripts/emit_nvidia_pins.py
+++ b/ansible/scripts/emit_nvidia_pins.py
@@ -139,7 +139,7 @@ def installed_nvidia_pins():
     return dict(sorted(pins.items()))
 
 
-def render(header, data):
+def render(header, data, closure_only=False):
     unknown = set(data) - KNOWN_KEYS
     if unknown:
         sys.exit(
@@ -147,8 +147,12 @@ def render(header, data):
             + ", ".join(sorted(unknown))
         )
     lines = [header.rstrip("\n")]
-    lines.append(f'ros_snapshot_date: "{data["ros_snapshot_date"]}"')
-    for key in ("apt_pins", "pip_pins", "nvidia_pins", "ros_overrides"):
+    if closure_only:
+        keys = ("nvidia_pins",)
+    else:
+        lines.append(f'ros_snapshot_date: "{data["ros_snapshot_date"]}"')
+        keys = ("apt_pins", "pip_pins", "nvidia_pins", "ros_overrides")
+    for key in keys:
         section = data.get(key) or {}
         if not section:
             lines.append(f"{key}: {{}}")
@@ -177,13 +181,18 @@ def main():
             header_lines.append(line)
         else:
             break
-    if "ros_snapshot_date" not in data:
+    # A consumer that overrides cuda_version/tensorrt_version keeps its closure in
+    # a file holding nvidia_pins alone, passed to version_lock as
+    # nvidia_lockfile_path. Such a file has no ROS sections to preserve, so
+    # ros_snapshot_date is not required of it — and must not be invented for it.
+    closure_only = set(data) <= {"nvidia_pins"}
+    if not closure_only and "ros_snapshot_date" not in data:
         sys.exit(f"Error: {path} has no ros_snapshot_date; is it a filled lockfile?")
     data["nvidia_pins"] = installed_nvidia_pins()
     # Render before truncating the output file: render() can sys.exit (e.g. on an
     # unknown top-level key), and opening in "w" mode truncates immediately, so
     # rendering first avoids destroying the lockfile on a failed run.
-    rendered = render("\n".join(header_lines), data)
+    rendered = render("\n".join(header_lines), data, closure_only=closure_only)
     with open(path, "w") as fh:
         fh.write(rendered)
     print(f"Updated nvidia_pins ({len(data['nvidia_pins'])} packages) in {path}")

--- a/ansible/vars/locked-versions-humble-amd64.yaml
+++ b/ansible/vars/locked-versions-humble-amd64.yaml
@@ -15,6 +15,7 @@ apt_pins:
   git-lfs: 3.0.2-1ubuntu0.3
   golang: 2:1.18~0ubuntu2
   pipx: 1.0.0-1
+  python3-apt: 2.4.0ubuntu4.1
   python3-flake8-blind-except: 0.2.0-2
   python3-flake8-builtins: 1.5.3-3
   python3-flake8-class-newline: 1.6.0-2
@@ -28,6 +29,8 @@ apt_pins:
   python3-pytest-repeat: 0.9.1-2
   python3-pytest-rerunfailures: 10.2-1
   python3-setuptools: 59.6.0-1.2ubuntu0.22.04.3
+  qt5ct: 1.5-1build1
+  rsync: 3.2.7-0ubuntu0.22.04.7
   wget: 1.21.2-2ubuntu1.4
 pip_pins: {}
 nvidia_pins:

--- a/ansible/vars/locked-versions-humble-amd64.yaml
+++ b/ansible/vars/locked-versions-humble-amd64.yaml
@@ -31,6 +31,7 @@ apt_pins:
   python3-setuptools: 59.6.0-1.2ubuntu0.22.04.3
   qt5ct: 1.5-1build1
   rsync: 3.2.7-0ubuntu0.22.04.7
+  unzip: 6.0-26ubuntu3.2
   wget: 1.21.2-2ubuntu1.4
 pip_pins: {}
 nvidia_pins:

--- a/ansible/vars/locked-versions-humble-amd64.yaml
+++ b/ansible/vars/locked-versions-humble-amd64.yaml
@@ -28,7 +28,7 @@ apt_pins:
   python3-pytest-repeat: 0.9.1-2
   python3-pytest-rerunfailures: 10.2-1
   python3-setuptools: 59.6.0-1.2ubuntu0.22.04.3
-  wget: 1.21.2-2ubuntu1.1
+  wget: 1.21.2-2ubuntu1.4
 pip_pins: {}
 nvidia_pins:
   cuda-cccl-12-8: 12.8.90-1

--- a/ansible/vars/locked-versions-humble-amd64.yaml
+++ b/ansible/vars/locked-versions-humble-amd64.yaml
@@ -7,8 +7,11 @@
 # apt_pins are finalized by ansible/scripts/generate_ansible_lockfile.sh.
 ros_snapshot_date: "2026-05-14"
 apt_pins:
+  build-essential: 12.9ubuntu3
   ccache: 4.5.1-1
+  cmake: 3.22.1-1ubuntu1.22.04.2
   geographiclib-tools: 1.52-1
+  git: 1:2.34.1-1ubuntu1.17
   git-lfs: 3.0.2-1ubuntu0.3
   golang: 2:1.18~0ubuntu2
   pipx: 1.0.0-1
@@ -24,6 +27,7 @@ apt_pins:
   python3-pytest-cov: 3.0.0-1
   python3-pytest-repeat: 0.9.1-2
   python3-pytest-rerunfailures: 10.2-1
+  python3-setuptools: 59.6.0-1.2ubuntu0.22.04.3
   wget: 1.21.2-2ubuntu1.1
 pip_pins: {}
 nvidia_pins:

--- a/ansible/vars/locked-versions-humble-arm64.yaml
+++ b/ansible/vars/locked-versions-humble-arm64.yaml
@@ -30,6 +30,7 @@ apt_pins:
   python3-setuptools: 59.6.0-1.2ubuntu0.22.04.3
   qt5ct: 1.5-1build1
   rsync: 3.2.7-0ubuntu0.22.04.7
+  unzip: 6.0-26ubuntu3.2
   wget: 1.21.2-2ubuntu1.4
 pip_pins: {}
 nvidia_pins:

--- a/ansible/vars/locked-versions-humble-arm64.yaml
+++ b/ansible/vars/locked-versions-humble-arm64.yaml
@@ -27,7 +27,7 @@ apt_pins:
   python3-pytest-repeat: 0.9.1-2
   python3-pytest-rerunfailures: 10.2-1
   python3-setuptools: 59.6.0-1.2ubuntu0.22.04.3
-  wget: 1.21.2-2ubuntu1.1
+  wget: 1.21.2-2ubuntu1.4
 pip_pins: {}
 nvidia_pins:
   cuda-cccl-12-8: 12.8.90-1

--- a/ansible/vars/locked-versions-humble-arm64.yaml
+++ b/ansible/vars/locked-versions-humble-arm64.yaml
@@ -6,8 +6,11 @@
 # ros_snapshot_date freezes the entire ROS closure via snapshots.ros.org.
 ros_snapshot_date: "2026-05-14"
 apt_pins:
+  build-essential: 12.9ubuntu3
   ccache: 4.5.1-1
+  cmake: 3.22.1-1ubuntu1.22.04.2
   geographiclib-tools: 1.52-1
+  git: 1:2.34.1-1ubuntu1.17
   git-lfs: 3.0.2-1ubuntu0.3
   golang: 2:1.18~0ubuntu2
   pipx: 1.0.0-1
@@ -23,6 +26,7 @@ apt_pins:
   python3-pytest-cov: 3.0.0-1
   python3-pytest-repeat: 0.9.1-2
   python3-pytest-rerunfailures: 10.2-1
+  python3-setuptools: 59.6.0-1.2ubuntu0.22.04.3
   wget: 1.21.2-2ubuntu1.1
 pip_pins: {}
 nvidia_pins:

--- a/ansible/vars/locked-versions-humble-arm64.yaml
+++ b/ansible/vars/locked-versions-humble-arm64.yaml
@@ -14,6 +14,7 @@ apt_pins:
   git-lfs: 3.0.2-1ubuntu0.3
   golang: 2:1.18~0ubuntu2
   pipx: 1.0.0-1
+  python3-apt: 2.4.0ubuntu4.1
   python3-flake8-blind-except: 0.2.0-2
   python3-flake8-builtins: 1.5.3-3
   python3-flake8-class-newline: 1.6.0-2
@@ -27,6 +28,8 @@ apt_pins:
   python3-pytest-repeat: 0.9.1-2
   python3-pytest-rerunfailures: 10.2-1
   python3-setuptools: 59.6.0-1.2ubuntu0.22.04.3
+  qt5ct: 1.5-1build1
+  rsync: 3.2.7-0ubuntu0.22.04.7
   wget: 1.21.2-2ubuntu1.4
 pip_pins: {}
 nvidia_pins:

--- a/ansible/vars/locked-versions-jazzy-amd64.yaml
+++ b/ansible/vars/locked-versions-jazzy-amd64.yaml
@@ -15,6 +15,7 @@ apt_pins:
   git-lfs: 3.4.1-1ubuntu0.4
   golang: 2:1.22~2build1
   pipx: 1.4.3-1
+  python3-apt: 2.7.7ubuntu5.2
   python3-flake8-blind-except: 0.2.1-1
   python3-flake8-builtins: 2.1.0-1
   python3-flake8-class-newline: 1.6.0-5
@@ -28,6 +29,8 @@ apt_pins:
   python3-pytest-repeat: 0.9.3-1
   python3-pytest-rerunfailures: 12.0-1
   python3-setuptools: 68.1.2-2ubuntu1.2
+  qt5ct: 1.5-1build11
+  rsync: 3.2.7-1ubuntu1.5
   wget: 1.21.4-1ubuntu4.4
 pip_pins: {}
 nvidia_pins:

--- a/ansible/vars/locked-versions-jazzy-amd64.yaml
+++ b/ansible/vars/locked-versions-jazzy-amd64.yaml
@@ -7,8 +7,11 @@
 # apt_pins are finalized by ansible/scripts/generate_ansible_lockfile.sh.
 ros_snapshot_date: "2026-04-13"
 apt_pins:
+  build-essential: 12.10ubuntu1
   ccache: 4.9.1-1
+  cmake: 3.28.3-1build7
   geographiclib-tools: 2.3-1build1
+  git: 1:2.43.0-1ubuntu7.3
   git-lfs: 3.4.1-1ubuntu0.4
   golang: 2:1.22~2build1
   pipx: 1.4.3-1
@@ -24,6 +27,7 @@ apt_pins:
   python3-pytest-cov: 4.1.0-1
   python3-pytest-repeat: 0.9.3-1
   python3-pytest-rerunfailures: 12.0-1
+  python3-setuptools: 68.1.2-2ubuntu1.2
   wget: 1.21.4-1ubuntu4.1
 pip_pins: {}
 nvidia_pins:

--- a/ansible/vars/locked-versions-jazzy-amd64.yaml
+++ b/ansible/vars/locked-versions-jazzy-amd64.yaml
@@ -28,7 +28,7 @@ apt_pins:
   python3-pytest-repeat: 0.9.3-1
   python3-pytest-rerunfailures: 12.0-1
   python3-setuptools: 68.1.2-2ubuntu1.2
-  wget: 1.21.4-1ubuntu4.1
+  wget: 1.21.4-1ubuntu4.4
 pip_pins: {}
 nvidia_pins:
   cuda-cccl-13-0: 13.0.85-1

--- a/ansible/vars/locked-versions-jazzy-amd64.yaml
+++ b/ansible/vars/locked-versions-jazzy-amd64.yaml
@@ -31,6 +31,7 @@ apt_pins:
   python3-setuptools: 68.1.2-2ubuntu1.2
   qt5ct: 1.5-1build11
   rsync: 3.2.7-1ubuntu1.5
+  unzip: 6.0-28ubuntu4.1
   wget: 1.21.4-1ubuntu4.4
 pip_pins: {}
 nvidia_pins:

--- a/ansible/vars/locked-versions-jazzy-arm64.yaml
+++ b/ansible/vars/locked-versions-jazzy-arm64.yaml
@@ -30,6 +30,7 @@ apt_pins:
   python3-setuptools: 68.1.2-2ubuntu1.2
   qt5ct: 1.5-1build11
   rsync: 3.2.7-1ubuntu1.5
+  unzip: 6.0-28ubuntu4.1
   wget: 1.21.4-1ubuntu4.4
 pip_pins: {}
 nvidia_pins:

--- a/ansible/vars/locked-versions-jazzy-arm64.yaml
+++ b/ansible/vars/locked-versions-jazzy-arm64.yaml
@@ -14,6 +14,7 @@ apt_pins:
   git-lfs: 3.4.1-1ubuntu0.4
   golang: 2:1.22~2build1
   pipx: 1.4.3-1
+  python3-apt: 2.7.7ubuntu5.2
   python3-flake8-blind-except: 0.2.1-1
   python3-flake8-builtins: 2.1.0-1
   python3-flake8-class-newline: 1.6.0-5
@@ -27,6 +28,8 @@ apt_pins:
   python3-pytest-repeat: 0.9.3-1
   python3-pytest-rerunfailures: 12.0-1
   python3-setuptools: 68.1.2-2ubuntu1.2
+  qt5ct: 1.5-1build11
+  rsync: 3.2.7-1ubuntu1.5
   wget: 1.21.4-1ubuntu4.4
 pip_pins: {}
 nvidia_pins:

--- a/ansible/vars/locked-versions-jazzy-arm64.yaml
+++ b/ansible/vars/locked-versions-jazzy-arm64.yaml
@@ -27,7 +27,7 @@ apt_pins:
   python3-pytest-repeat: 0.9.3-1
   python3-pytest-rerunfailures: 12.0-1
   python3-setuptools: 68.1.2-2ubuntu1.2
-  wget: 1.21.4-1ubuntu4.1
+  wget: 1.21.4-1ubuntu4.4
 pip_pins: {}
 nvidia_pins:
   cuda-cccl-13-0: 13.0.85-1

--- a/ansible/vars/locked-versions-jazzy-arm64.yaml
+++ b/ansible/vars/locked-versions-jazzy-arm64.yaml
@@ -6,8 +6,11 @@
 # ros_snapshot_date freezes the entire ROS closure via snapshots.ros.org.
 ros_snapshot_date: "2026-04-13"
 apt_pins:
+  build-essential: 12.10ubuntu1
   ccache: 4.9.1-1
+  cmake: 3.28.3-1build7
   geographiclib-tools: 2.3-1build1
+  git: 1:2.43.0-1ubuntu7.3
   git-lfs: 3.4.1-1ubuntu0.4
   golang: 2:1.22~2build1
   pipx: 1.4.3-1
@@ -23,6 +26,7 @@ apt_pins:
   python3-pytest-cov: 4.1.0-1
   python3-pytest-repeat: 0.9.3-1
   python3-pytest-rerunfailures: 12.0-1
+  python3-setuptools: 68.1.2-2ubuntu1.2
   wget: 1.21.4-1ubuntu4.1
 pip_pins: {}
 nvidia_pins:

--- a/docker/README.md
+++ b/docker/README.md
@@ -116,13 +116,13 @@ USE_LOCKFILE=true ROS_DISTRO=humble docker buildx bake -f docker/docker-bake.hcl
 When enabled, the build:
 
 - pins the base image to the per-distro digest in `BASE_IMAGE_DIGESTS` (`docker/docker-bake.hcl`) instead of the floating `ros:<distro>-ros-base` tag, freezing the OS-level closure;
-- passes `use_locked_versions=true` to ansible, which pins Ubuntu-archive packages to the versions in `ansible/vars/locked-versions-<distro>-<arch>.yaml` and points ROS at the dated `snapshots.ros.org` source recorded in that lockfile, freezing the entire ROS dependency closure;
-- walks any package the base image preinstalled at a different version than the snapshot back to the snapshot's version (the floating `ros:<distro>-ros-base` tag is usually newer than the lockfile's `ros_snapshot_date`), so the ROS closure in the final image is entirely snapshot-served; and
+- passes `use_locked_versions=true` to ansible, which pins Ubuntu-archive packages to the versions in `ansible/vars/locked-versions-<distro>-<arch>.yaml` and points ROS at the dated `snapshots.ros.org` source recorded in that lockfile, freezing every ROS dependency that snapshot serves;
+- walks any package the base image preinstalled at a different version than the snapshot back to the snapshot's version (the floating `ros:<distro>-ros-base` tag is usually newer than the lockfile's `ros_snapshot_date`), so every snapshot-served package in the final image is at its snapshot version; and
 - verifies after install that every locked package landed at its pinned version, failing the build on any drift.
 
 Only distros that have **both** a lockfile and a `BASE_IMAGE_DIGESTS` entry can be built in locked mode (currently `humble` and `jazzy`); requesting `USE_LOCKFILE=true` for any other `ROS_DISTRO` fails the build rather than silently falling back to a floating base. The CUDA targets (`base-cuda-*`, `universe-cuda`) also build in locked mode: they inherit the frozen apt pins and dated snapshot from the `base` image they build on, and the CUDA / cuDNN / TensorRT closure from NVIDIA's apt repositories is frozen by the lockfile's `nvidia_pins` section. NVIDIA publishes no dated snapshot, so that closure is pinned by exact version per package (see the version_lock README for how `nvidia_pins` is recorded).
 
-See [`ansible/roles/version_lock/README.md`](../ansible/roles/version_lock/README.md) for the lockfile format and how to generate or update lockfiles.
+Locked mode is not a hermetic build. The rolling `packages.ros.org` source stays configured, so a `ros-*` package the dated snapshot does not carry — Autoware's own released packages among them — still installs from rolling and floats. See "What the freeze does not cover" in [`ansible/roles/version_lock/README.md`](../ansible/roles/version_lock/README.md), which also documents the lockfile format and how to generate or update lockfiles.
 
 ## Usage
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -116,10 +116,11 @@ USE_LOCKFILE=true ROS_DISTRO=humble docker buildx bake -f docker/docker-bake.hcl
 When enabled, the build:
 
 - pins the base image to the per-distro digest in `BASE_IMAGE_DIGESTS` (`docker/docker-bake.hcl`) instead of the floating `ros:<distro>-ros-base` tag, freezing the OS-level closure;
-- passes `use_locked_versions=true` to ansible, which pins Ubuntu-archive packages to the versions in `ansible/vars/locked-versions-<distro>-<arch>.yaml` and points ROS at the dated `snapshots.ros.org` source recorded in that lockfile, freezing the entire ROS dependency closure; and
+- passes `use_locked_versions=true` to ansible, which pins Ubuntu-archive packages to the versions in `ansible/vars/locked-versions-<distro>-<arch>.yaml` and points ROS at the dated `snapshots.ros.org` source recorded in that lockfile, freezing the entire ROS dependency closure;
+- walks any package the base image preinstalled at a different version than the snapshot back to the snapshot's version (the floating `ros:<distro>-ros-base` tag is usually newer than the lockfile's `ros_snapshot_date`), so the ROS closure in the final image is entirely snapshot-served; and
 - verifies after install that every locked package landed at its pinned version, failing the build on any drift.
 
-Only distros that have **both** a lockfile and a `BASE_IMAGE_DIGESTS` entry can be built in locked mode (currently `humble` and `jazzy`); requesting `USE_LOCKFILE=true` for any other `ROS_DISTRO` fails the build rather than silently falling back to a floating base. The CUDA targets (`base-cuda-*`, `universe-cuda`) are intentionally not locked: they inherit the frozen apt pins and dated snapshot from the `base` image they build on, but the CUDA / cuDNN / TensorRT packages from NVIDIA's apt repositories are not yet covered by the lockfile.
+Only distros that have **both** a lockfile and a `BASE_IMAGE_DIGESTS` entry can be built in locked mode (currently `humble` and `jazzy`); requesting `USE_LOCKFILE=true` for any other `ROS_DISTRO` fails the build rather than silently falling back to a floating base. The CUDA targets (`base-cuda-*`, `universe-cuda`) also build in locked mode: they inherit the frozen apt pins and dated snapshot from the `base` image they build on, and the CUDA / cuDNN / TensorRT closure from NVIDIA's apt repositories is frozen by the lockfile's `nvidia_pins` section. NVIDIA publishes no dated snapshot, so that closure is pinned by exact version per package (see the version_lock README for how `nvidia_pins` is recorded).
 
 See [`ansible/roles/version_lock/README.md`](../ansible/roles/version_lock/README.md) for the lockfile format and how to generate or update lockfiles.
 


### PR DESCRIPTION
## Description

Verification-only PR. Stages the code-review fixes for autowarefoundation/autoware#7237 together with #7238's three CI files, so the locked lanes actually exercise them. Not intended for merge, and the last commit merges fork `main` purely for Ubicloud runner routing.

Seven fixes on top of #7237's head (`0a1adda`):

1. **Blocking — the three new `command` tasks invoked a bare `python3`.** It resolves from the invoking user's `PATH`, but `python3-apt` installs only into the system interpreter, so any active venv breaks locked mode one task after it installs `python3-apt`. Fixed with an absolute `/usr/bin/python3`. The review suggested `{{ ansible_python_interpreter | default('/usr/bin/python3') }}`, which does not work here: these plays run against the implicit localhost, for which Ansible sets that variable to its own `sys.executable`, and Autoware installs Ansible with pipx (`scripts/install-ansible.sh`, `base.Dockerfile`), so it always points at a venv with no apt bindings. `ansible.builtin.script` fails for the same reason — its shebang is `/usr/bin/env python3`.
2. The pre-existing drift `fail_msg` still had the literal `\n` bug fixed at three other sites. It needs it most: `quiet: true` makes it the only place the list is shown.
3. `qt5ct_setup`'s `state: latest` installs now `update_cache`, matching `rmw_implementation`.
4. The `cuda` and `tensorrt` closure guards no longer skip on an empty `nvidia_pins` — the one input for which they are most needed.
5. `unzip` is pinned in all four lockfiles; `demo_artifacts` installs it top-level, so a locked `--tags demo_artifacts` run failed the new completeness assert.
6. `version_lock/README.md`: the `nvidia_lockfile_path` example needed `rosdistro`; `emit_nvidia_pins.py` does not import `python3-apt`; the third-party PPA cases are three, not two (`agnocast_kmod_package`).
7. `docker/README.md` claimed locked mode freezes "the entire ROS dependency closure". It does not — the rolling source stays configured, so `ros-*` packages the snapshot lacks (71 `ros-jazzy-autoware-*` among them) install from rolling and float. Claim narrowed; three more surfaces added to "What the freeze does not cover".

## How was this PR tested?

Locally: `ansible-lint --offline ansible/` passes at profile `production`, all four playbooks `--syntax-check` clean, `validate_lockfiles.sh` passes, pre-commit clean.

The interpreter fix was measured on ansible-core 2.17.14 by running the same `import apt` probe four ways from a `connection: local` play, with and without a venv on `PATH`:

| interpreter | pipx ansible, no venv on PATH | venv on PATH |
| --- | --- | --- |
| bare `python3` (before) | ok | **fail** |
| `ansible_python_interpreter \| default(...)` | **fail** | **fail** |
| `/usr/bin/python3` (after) | ok | ok |
| `ansible.builtin.script` | ok | **fail** |

Both `unzip` pins are the current archive candidates, checked against Launchpad (jammy `6.0-26ubuntu3.2`) and a live noble `apt-cache madison` (`6.0-28ubuntu4.1`).

CI here is the point: `health-check-ansible` runs `{ubuntu:22.04, ubuntu:24.04} × {locked, unlocked}` and `validate-lockfiles` runs `build-locked-base`, so the locked cells exercise every fix above.
